### PR TITLE
feat(frontend): guided UX overhaul for import/start/play flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ npm run dev
 Abrir: `http://localhost:5173`
 
 ## Uso con PDF real
-1. En la UI, pulsa `Importar Libro`.
-2. Usa una ruta como: `file:///C:/Users/<usuario>/Downloads/libro.pdf`
-3. Inicia partida y juega por escenas.
+1. En `1. Preparar partida`, usa `Importar libro` con ruta como `file:///C:/Users/<usuario>/Downloads/libro.pdf`.
+2. Selecciona el libro importado y pulsa `2. Iniciar partida`.
+3. En `3. Jugar`, avanza por escenas con `Dialogar`, `Explorar`, `Resolver reto` o `Usar item`.
+4. Para continuar luego, usa `Cargar sesion` con el `sessionId` (tambien se recuerda automaticamente en el navegador).
 
 ## Release desktop
 - Release publico actual: `v3.1.0`

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -18,9 +18,15 @@ npm run build
 ## Variables
 - `VITE_API_BASE` (default: `http://localhost:8080/api`)
 
-## Flujo UX
-1. Importar libro (`file:///...pdf` o ruta local).
-2. Seleccionar libro y jugador.
-3. Iniciar partida.
-4. Ejecutar acciones por escena (`TALK`, `EXPLORE`, `CHALLENGE`, `USE_ITEM`).
-5. Continuar con `sessionId`.
+## Flujo UX guiado (v3)
+1. `Preparar partida`: define jugador e importa libro (`file:///...pdf` o ruta local).
+2. `Iniciar partida` o `Cargar sesion`: arranca desde libro seleccionado o reanuda por `sessionId`.
+3. `Jugar`: avanza por escenas con acciones guiadas:
+   - `Dialogar`
+   - `Explorar`
+   - `Resolver reto` (seleccion de respuesta)
+   - `Usar item` (seleccion de inventario)
+
+## Estado de sesion
+- El frontend guarda el ultimo `sessionId` en `localStorage` con la clave `autobook:lastSessionId`.
+- Al recargar la pagina, ese `sessionId` aparece automaticamente en el campo de reanudacion.

--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -1,11 +1,18 @@
 :root {
-  --bg: radial-gradient(circle at 10% 20%, #f5f0e8 0%, #dfe9f1 45%, #d2d8c6 100%);
-  --paper: #fff8ec;
-  --ink: #1f2833;
-  --accent: #1d6f8c;
-  --accent-2: #9d4d2f;
-  --ok: #2a7f62;
-  --warn: #9f2d2d;
+  --bg: radial-gradient(circle at 0 0, #ffedd4 0%, #d9eef6 35%, #bfd8c8 100%);
+  --surface: #fffdf8;
+  --surface-strong: #fff8ec;
+  --line: #355a63;
+  --line-soft: #6e8e96;
+  --ink: #1a2c35;
+  --ink-soft: #4a5f68;
+  --brand: #1f6f8b;
+  --brand-strong: #154f67;
+  --accent: #b7603c;
+  --ok: #207657;
+  --warn: #a4362a;
+  --shadow: 0 12px 26px rgba(29, 52, 63, 0.15);
+  --radius: 16px;
 }
 
 * {
@@ -14,147 +21,378 @@
 
 body {
   margin: 0;
+  min-height: 100vh;
   font-family: "Trebuchet MS", "Lucida Grande", "Lucida Sans Unicode", sans-serif;
   color: var(--ink);
   background: var(--bg);
-  min-height: 100vh;
 }
 
-.layout {
-  max-width: 1200px;
+.app-shell {
+  width: min(1250px, 100%);
   margin: 0 auto;
-  padding: 1.2rem;
-}
-
-.hero {
-  border: 2px solid #2e4858;
-  border-radius: 14px;
-  padding: 1rem 1.2rem;
-  background: linear-gradient(120deg, #f8f1e7 0%, #e4f0f5 100%);
-  box-shadow: 0 8px 18px rgba(46, 72, 88, 0.15);
-  animation: rise 0.4s ease;
-}
-
-.hero h1 {
-  margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  letter-spacing: 0.04em;
-}
-
-.grid {
+  padding: 1.25rem;
   display: grid;
-  grid-template-columns: 1fr 2fr;
   gap: 1rem;
-  margin-top: 1rem;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  background: linear-gradient(130deg, #fff7e7 0%, #edf6fb 100%);
+  border: 2px solid var(--line);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.topbar h1 {
+  margin: 0.2rem 0 0.35rem;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.topbar-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  background: #ffffffb5;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.85rem;
+}
+
+.dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+}
+
+.dot.idle {
+  background: var(--ok);
+}
+
+.dot.busy {
+  background: var(--accent);
+  animation: pulse 0.9s ease infinite alternate;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 1rem;
+  align-items: start;
 }
 
 .panel {
-  background: var(--paper);
-  border: 2px solid #3f5b6c;
-  border-radius: 14px;
+  background: var(--surface);
+  border: 2px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
   padding: 1rem;
-  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.1);
+}
+
+.setup-panel h2,
+.play-panel h2 {
+  margin-top: 0;
+}
+
+.setup-panel h3 {
+  margin: 1rem 0 0.6rem;
+  color: var(--brand-strong);
 }
 
 label {
-  display: block;
-  margin-bottom: 0.8rem;
-  font-size: 0.92rem;
+  display: grid;
+  gap: 0.3rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ink-soft);
 }
 
 input,
 select,
 button {
   width: 100%;
-  margin-top: 0.25rem;
-  border-radius: 10px;
-  border: 1px solid #557185;
-  padding: 0.56rem 0.65rem;
-  font-size: 0.95rem;
+  border-radius: 11px;
+  padding: 0.58rem 0.65rem;
+  font-size: 0.94rem;
+}
+
+input,
+select {
+  border: 1px solid var(--line-soft);
+  background: #fff;
+  color: var(--ink);
+}
+
+input:focus,
+select:focus,
+button:focus-visible {
+  outline: 2px solid #94c7d9;
+  outline-offset: 1px;
 }
 
 button {
+  border: 0;
   cursor: pointer;
-  background: linear-gradient(140deg, var(--accent) 0%, #2d5f8a 100%);
-  color: #fff;
-  border: none;
   font-weight: 700;
+  color: #fff;
+  background: linear-gradient(150deg, var(--brand) 0%, var(--brand-strong) 100%);
+  transition: transform 0.12s ease, filter 0.12s ease;
 }
 
-button:hover {
-  filter: brightness(1.05);
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  filter: brightness(1.04);
 }
 
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.55;
 }
 
 .row {
   display: flex;
   gap: 0.6rem;
-  margin-bottom: 0.8rem;
+  margin-bottom: 0.85rem;
 }
 
-.row.wrap {
-  flex-wrap: wrap;
-}
-
-.row.wrap button {
-  flex: 1 1 130px;
+.placeholder {
+  color: var(--ink-soft);
+  margin: 0;
 }
 
 .hud {
-  border-left: 4px solid var(--accent-2);
-  padding-left: 0.8rem;
-  background: #fff3df;
-  border-radius: 8px;
+  display: grid;
+  gap: 0.8rem;
+  background: linear-gradient(120deg, #fff4df 0%, #fff 100%);
+  border: 1px solid #e4d2bc;
+  border-radius: 12px;
+  padding: 0.8rem;
 }
 
-.scene {
-  border: 1px dashed #49657b;
-  border-radius: 10px;
+.hud-title {
+  margin: 0 0 0.3rem;
+  font-size: 1rem;
+  color: var(--brand-strong);
+}
+
+.hud p {
+  margin: 0;
+}
+
+.progress-wrap {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.progress-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+}
+
+.progress-bar {
+  background: #e9edf0;
+  height: 0.62rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #2a9db6 0%, #2d7f7e 100%);
+  transition: width 0.25s ease;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+}
+
+.metric {
+  border-radius: 11px;
+  border: 1px solid #d4dde1;
+  background: #fff;
+  padding: 0.6rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.metric span {
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+}
+
+.metric strong {
+  font-size: 1.05rem;
+}
+
+.metric-life {
+  border-bottom: 3px solid #cf3f3f;
+}
+
+.metric-knowledge {
+  border-bottom: 3px solid #2669a8;
+}
+
+.metric-courage {
+  border-bottom: 3px solid #b26a2a;
+}
+
+.metric-focus {
+  border-bottom: 3px solid #4c8a3b;
+}
+
+.metric-score {
+  border-bottom: 3px solid #7544b6;
+}
+
+.scene-card {
+  margin-top: 0.85rem;
+  border: 1px dashed #6e8e96;
+  border-radius: 12px;
+  background: var(--surface-strong);
+  padding: 0.85rem;
+}
+
+.scene-card h3 {
+  margin: 0 0 0.45rem;
+}
+
+.scene-meta {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.scene-text {
+  margin: 0.65rem 0 0;
+  line-height: 1.45;
+}
+
+.scene-card.complete {
+  border-style: solid;
+  border-color: #6ab394;
+}
+
+.actions-panel {
+  margin-top: 0.9rem;
+  border: 1px solid #d4dde1;
+  border-radius: 12px;
   padding: 0.8rem;
-  margin: 0.8rem 0;
   background: #fff;
 }
 
-.event-tag {
-  color: var(--accent-2);
+.actions-panel h3 {
+  margin: 0 0 0.6rem;
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin-bottom: 0.7rem;
+}
+
+.action-tile {
+  text-align: left;
+  border: 1px solid #aac4cb;
+  background: #f5fbfd;
+  color: var(--ink);
+  padding: 0.65rem;
+}
+
+.action-tile.selected {
+  border-color: var(--brand-strong);
+  background: linear-gradient(130deg, #dcf0f5 0%, #ecf7f9 100%);
+}
+
+.action-label {
+  display: block;
   font-weight: 700;
 }
 
-.npc-tag {
-  color: #37546a;
-  font-style: italic;
+.action-desc {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--ink-soft);
+  font-size: 0.83rem;
+  line-height: 1.3;
 }
 
-.meta ul,
-.meta li {
+.play-button {
+  margin-top: 0.35rem;
+  background: linear-gradient(135deg, #ca6d47 0%, #a85433 100%);
+}
+
+.bottom-grid {
+  margin-top: 0.9rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.mini-panel {
+  border: 1px solid #d4dde1;
+  border-radius: 11px;
+  background: #fff;
+  padding: 0.75rem;
+}
+
+.mini-panel h4 {
+  margin: 0 0 0.55rem;
+}
+
+.mini-panel ul {
   margin: 0;
-  padding: 0;
-  list-style: none;
+  padding-left: 1rem;
 }
 
-.meta li {
-  margin-bottom: 0.3rem;
+.mini-panel li {
+  margin-bottom: 0.25rem;
 }
 
-.meta .done {
+.quest-done {
   color: var(--ok);
   font-weight: 700;
 }
 
-.meta .pending {
-  color: #526273;
+.quest-pending {
+  color: var(--ink-soft);
 }
 
-.status {
-  margin-top: 1rem;
-  border-radius: 10px;
-  border: 1px solid #476176;
-  padding: 0.7rem;
-  background: #f9f6ef;
+.feedback-strip {
+  display: grid;
+  gap: 0.25rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  background: #f8fbfc;
+  padding: 0.75rem;
+}
+
+.feedback-strip p {
+  margin: 0;
 }
 
 .error {
@@ -162,23 +400,50 @@ button:disabled {
   font-weight: 700;
 }
 
-@keyframes rise {
+@keyframes pulse {
   from {
-    transform: translateY(6px);
-    opacity: 0;
+    transform: scale(1);
+    opacity: 0.7;
   }
   to {
-    transform: translateY(0);
+    transform: scale(1.15);
     opacity: 1;
   }
 }
 
-@media (max-width: 900px) {
-  .grid {
+@media (max-width: 1120px) {
+  .content-grid {
     grid-template-columns: 1fr;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .app-shell {
+    padding: 0.8rem;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .row {
     flex-direction: column;
+  }
+
+  .action-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bottom-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -5,6 +5,47 @@ import type { BookView, GameState } from "./types";
 
 type ActionKind = "TALK" | "EXPLORE" | "CHALLENGE" | "USE_ITEM";
 
+type ActionDescriptor = {
+  key: ActionKind;
+  label: string;
+  description: string;
+  needsChallenge: boolean;
+  needsItem: boolean;
+};
+
+const ACTIONS: ActionDescriptor[] = [
+  {
+    key: "TALK",
+    label: "Dialogar",
+    description: "Habla con el personaje para obtener contexto y progreso seguro.",
+    needsChallenge: false,
+    needsItem: false,
+  },
+  {
+    key: "EXPLORE",
+    label: "Explorar",
+    description: "Busca recursos y descubrimientos. Puede incluir riesgo.",
+    needsChallenge: false,
+    needsItem: false,
+  },
+  {
+    key: "CHALLENGE",
+    label: "Resolver reto",
+    description: "Responde una pregunta de lectura para ganar conocimiento.",
+    needsChallenge: true,
+    needsItem: false,
+  },
+  {
+    key: "USE_ITEM",
+    label: "Usar item",
+    description: "Consume un item del inventario para obtener ventaja.",
+    needsChallenge: false,
+    needsItem: true,
+  },
+];
+
+const SESSION_KEY = "autobook:lastSessionId";
+
 function App() {
   const [books, setBooks] = useState<BookView[]>([]);
   const [selectedBookPath, setSelectedBookPath] = useState<string>("");
@@ -15,15 +56,29 @@ function App() {
   const [sessionIdInput, setSessionIdInput] = useState<string>("");
   const [answerIndex, setAnswerIndex] = useState<number>(1);
   const [selectedItemId, setSelectedItemId] = useState<string>("");
+  const [selectedAction, setSelectedAction] = useState<ActionKind>("TALK");
   const [state, setState] = useState<GameState | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string>("Listo para iniciar.");
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
+
+  const activeAction = useMemo(
+    () => ACTIONS.find((action) => action.key === selectedAction) ?? ACTIONS[0],
+    [selectedAction],
+  );
 
   const inventoryEntries = useMemo(() => {
     if (!state) {
       return [] as Array<[string, number]>;
     }
     return Object.entries(state.inventory);
+  }, [state]);
+
+  const progress = useMemo(() => {
+    if (!state?.currentScene) {
+      return 0;
+    }
+    return Math.floor(((state.currentScene.index + 1) / state.currentScene.total) * 100);
   }, [state]);
 
   const refreshBooks = useCallback(async () => {
@@ -36,21 +91,37 @@ function App() {
 
   useEffect(() => {
     refreshBooks().catch(() => {
-      // no-op on initial load
+      setError("No se pudo cargar el catalogo inicial.");
     });
   }, [refreshBooks]);
 
-  async function withRequest(task: () => Promise<void>) {
+  useEffect(() => {
+    const savedSession = localStorage.getItem(SESSION_KEY);
+    if (savedSession) {
+      setSessionIdInput(savedSession);
+    }
+  }, []);
+
+  async function withRequest(task: () => Promise<void>, successMessage?: string) {
     setLoading(true);
     setError("");
     try {
       await task();
+      if (successMessage) {
+        setStatusMessage(successMessage);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Error inesperado.";
       setError(message);
+      setStatusMessage("Operacion fallida.");
     } finally {
       setLoading(false);
     }
+  }
+
+  function persistSession(sessionId: string) {
+    setSessionIdInput(sessionId);
+    localStorage.setItem(SESSION_KEY, sessionId);
   }
 
   function resolveItemId() {
@@ -60,26 +131,54 @@ function App() {
     return inventoryEntries.length > 0 ? inventoryEntries[0][0] : "";
   }
 
-  return (
-    <main className="layout">
-      <section className="hero">
-        <h1>AutoBook Quest Lab</h1>
-        <p>
-          Convierte libros en una aventura interactiva. Importa, juega, responde retos y
-          completa quests.
-        </p>
-      </section>
+  function canSendAction(): boolean {
+    if (!state?.currentScene || state.completed) {
+      return false;
+    }
+    if (activeAction.needsItem && inventoryEntries.length === 0) {
+      return false;
+    }
+    return true;
+  }
 
-      <section className="grid">
-        <article className="panel controls">
-          <h2>Control</h2>
+  async function executeSelectedAction() {
+    if (!state) {
+      return;
+    }
+    const itemId = activeAction.needsItem ? resolveItemId() : undefined;
+    const challengeAnswer = activeAction.needsChallenge ? answerIndex : undefined;
+    const result = await sendAction(state.sessionId, activeAction.key, challengeAnswer, itemId);
+    setState(result);
+    setStatusMessage(result.lastMessage);
+  }
+
+  return (
+    <main className="app-shell">
+      <header className="topbar">
+        <div>
+          <p className="eyebrow">Lectura interactiva</p>
+          <h1>AutoBook Quest</h1>
+          <p className="subtitle">
+            Flujo guiado: importa un libro, inicia sesion y juega escena por escena.
+          </p>
+        </div>
+        <div className="topbar-status">
+          <span className={`dot ${loading ? "busy" : "idle"}`} />
+          <span>{loading ? "Procesando" : "Disponible"}</span>
+        </div>
+      </header>
+
+      <section className="content-grid">
+        <aside className="panel setup-panel">
+          <h2>1. Preparar partida</h2>
+
           <label>
             Nombre del jugador
             <input value={playerName} onChange={(e) => setPlayerName(e.target.value)} />
           </label>
 
           <label>
-            Ruta para importar (.txt/.pdf)
+            Ruta de libro (.txt/.pdf)
             <input value={importPath} onChange={(e) => setImportPath(e.target.value)} />
           </label>
 
@@ -90,22 +189,19 @@ function App() {
                 withRequest(async () => {
                   await importBook(importPath);
                   await refreshBooks();
-                })
+                }, "Libro importado y catalogo actualizado.")
               }
             >
-              Importar Libro
+              Importar libro
             </button>
-            <button disabled={loading} onClick={() => withRequest(refreshBooks)}>
-              Refrescar Catalogo
+            <button disabled={loading} onClick={() => withRequest(refreshBooks, "Catalogo actualizado.")}>
+              Refrescar
             </button>
           </div>
 
           <label>
-            Libro seleccionado
-            <select
-              value={selectedBookPath}
-              onChange={(e) => setSelectedBookPath(e.target.value)}
-            >
+            Libro elegido
+            <select value={selectedBookPath} onChange={(e) => setSelectedBookPath(e.target.value)}>
               {books.map((book) => (
                 <option key={book.path} value={book.path}>
                   {book.title} [{book.format}]
@@ -121,14 +217,16 @@ function App() {
                 withRequest(async () => {
                   const result = await startGame(playerName, selectedBookPath);
                   setState(result);
-                  setSessionIdInput(result.sessionId);
-                })
+                  persistSession(result.sessionId);
+                  setSelectedAction("TALK");
+                }, "Partida iniciada correctamente.")
               }
             >
-              Iniciar Partida
+              2. Iniciar partida
             </button>
           </div>
 
+          <h3>Reanudar sesion</h3>
           <label>
             Session ID
             <input
@@ -143,138 +241,174 @@ function App() {
               withRequest(async () => {
                 const loaded = await loadState(sessionIdInput);
                 setState(loaded);
-              })
+                persistSession(sessionIdInput);
+              }, "Sesion cargada.")
             }
           >
-            Cargar Sesion
+            Cargar sesion
           </button>
-        </article>
+        </aside>
 
-        <article className="panel gameplay">
-          <h2>Partida</h2>
-          {!state && <p>Inicia una partida para ver la escena jugable.</p>}
+        <section className="panel play-panel">
+          <h2>3. Jugar</h2>
+          {!state && <p className="placeholder">Inicia o carga una sesion para comenzar.</p>}
 
           {state && (
             <>
-              <header className="hud">
-                <p>
-                  <strong>{state.playerName}</strong> · {state.bookTitle}
-                </p>
-                <p>
-                  Vida {state.life} | Conocimiento {state.knowledge} | Coraje {state.courage}
-                </p>
-                <p>
-                  Enfoque {state.focus} | Puntaje {state.score} | Correctas {state.correctAnswers}
-                </p>
-              </header>
+              <section className="hud">
+                <div>
+                  <p className="hud-title">{state.bookTitle}</p>
+                  <p>
+                    Jugador: <strong>{state.playerName}</strong>
+                  </p>
+                </div>
+                <div className="progress-wrap">
+                  <div className="progress-meta">
+                    <span>Progreso</span>
+                    <span>{progress}%</span>
+                  </div>
+                  <div className="progress-bar">
+                    <div className="progress-fill" style={{ width: `${progress}%` }} />
+                  </div>
+                </div>
+              </section>
+
+              <section className="stats-grid">
+                <Metric label="Vida" value={state.life} variant="life" />
+                <Metric label="Conocimiento" value={state.knowledge} variant="knowledge" />
+                <Metric label="Coraje" value={state.courage} variant="courage" />
+                <Metric label="Enfoque" value={state.focus} variant="focus" />
+                <Metric label="Puntaje" value={state.score} variant="score" />
+              </section>
 
               {state.currentScene ? (
-                <section className="scene">
+                <article className="scene-card">
                   <h3>
                     {state.currentScene.title} ({state.currentScene.index + 1}/{state.currentScene.total})
                   </h3>
-                  <p className="event-tag">Evento: {state.currentScene.eventType}</p>
-                  <p className="npc-tag">NPC: {state.currentScene.npc}</p>
-                  <p>{state.currentScene.text}</p>
-                </section>
+                  <p className="scene-meta">
+                    Evento: <strong>{state.currentScene.eventType}</strong> · NPC: <strong>{state.currentScene.npc}</strong>
+                  </p>
+                  <p className="scene-text">{state.currentScene.text}</p>
+                </article>
               ) : (
-                <section className="scene done">
-                  <h3>Aventura completada</h3>
-                  <p>La partida no tiene escenas pendientes.</p>
-                </section>
+                <article className="scene-card complete">
+                  <h3>Aventura finalizada</h3>
+                  <p>Ya no quedan escenas pendientes para esta sesion.</p>
+                </article>
               )}
 
-              <section className="actions">
-                <h3>Acciones</h3>
-                <div className="row wrap">
-                  {(["TALK", "EXPLORE", "CHALLENGE", "USE_ITEM"] as ActionKind[]).map((action) => (
+              <section className="actions-panel">
+                <h3>Accion recomendada</h3>
+                <div className="action-grid">
+                  {ACTIONS.map((action) => (
                     <button
-                      key={action}
-                      disabled={loading || !state.currentScene}
-                      onClick={() =>
-                        withRequest(async () => {
-                          const result = await sendAction(
-                            state.sessionId,
-                            action,
-                            action === "CHALLENGE" ? answerIndex : undefined,
-                            action === "USE_ITEM" ? resolveItemId() : undefined,
-                          );
-                          setState(result);
-                        })
-                      }
+                      key={action.key}
+                      className={`action-tile ${selectedAction === action.key ? "selected" : ""}`}
+                      onClick={() => setSelectedAction(action.key)}
+                      disabled={loading || !state.currentScene || state.completed}
                     >
-                      {action}
+                      <span className="action-label">{action.label}</span>
+                      <span className="action-desc">{action.description}</span>
                     </button>
                   ))}
                 </div>
 
-                {state.currentScene && (
-                  <>
-                    <label>
-                      Respuesta para CHALLENGE
-                      <select
-                        value={answerIndex}
-                        onChange={(e) => setAnswerIndex(Number(e.target.value))}
-                      >
-                        {state.currentScene.challenge.options.map((option, idx) => (
-                          <option key={option + idx} value={idx + 1}>
-                            {idx + 1}. {option}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-
-                    <label>
-                      Item para USE_ITEM
-                      <select
-                        value={selectedItemId}
-                        onChange={(e) => setSelectedItemId(e.target.value)}
-                      >
-                        <option value="">(auto)</option>
-                        {inventoryEntries.map(([id, qty]) => (
-                          <option key={id} value={id}>
-                            {id} x{qty}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                  </>
+                {state.currentScene && activeAction.needsChallenge && (
+                  <label>
+                    Respuesta del reto
+                    <select
+                      value={answerIndex}
+                      onChange={(e) => setAnswerIndex(Number(e.target.value))}
+                    >
+                      {state.currentScene.challenge.options.map((option, idx) => (
+                        <option key={option + idx} value={idx + 1}>
+                          {idx + 1}. {option}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
                 )}
+
+                {activeAction.needsItem && (
+                  <label>
+                    Item a usar
+                    <select
+                      value={selectedItemId}
+                      onChange={(e) => setSelectedItemId(e.target.value)}
+                    >
+                      <option value="">Seleccionar automaticamente</option>
+                      {inventoryEntries.map(([id, qty]) => (
+                        <option key={id} value={id}>
+                          {id} x{qty}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+
+                <button
+                  className="play-button"
+                  disabled={loading || !canSendAction()}
+                  onClick={() => withRequest(executeSelectedAction)}
+                >
+                  Ejecutar: {activeAction.label}
+                </button>
               </section>
 
-              <section className="meta">
-                <h3>Inventario</h3>
-                {inventoryEntries.length === 0 && <p>Vacio</p>}
-                {inventoryEntries.length > 0 && (
+              <section className="bottom-grid">
+                <article className="mini-panel">
+                  <h4>Inventario</h4>
+                  {inventoryEntries.length === 0 ? (
+                    <p>Sin items</p>
+                  ) : (
+                    <ul>
+                      {inventoryEntries.map(([id, qty]) => (
+                        <li key={id}>
+                          {id} x{qty}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </article>
+
+                <article className="mini-panel">
+                  <h4>Quests</h4>
                   <ul>
-                    {inventoryEntries.map(([id, qty]) => (
-                      <li key={id}>
-                        {id} x{qty}
+                    {state.quests.map((quest) => (
+                      <li key={quest.id} className={quest.completed ? "quest-done" : "quest-pending"}>
+                        {quest.title}
                       </li>
                     ))}
                   </ul>
-                )}
-
-                <h3>Quests</h3>
-                <ul>
-                  {state.quests.map((quest) => (
-                    <li key={quest.id} className={quest.completed ? "done" : "pending"}>
-                      {quest.title}: {quest.completed ? "COMPLETADA" : "PENDIENTE"}
-                    </li>
-                  ))}
-                </ul>
+                </article>
               </section>
             </>
           )}
-        </article>
+        </section>
       </section>
 
-      <section className="status">
-        <p>{loading ? "Procesando..." : "Listo."}</p>
-        <p>{state?.lastMessage ?? "Sin eventos aun."}</p>
+      <footer className="feedback-strip">
+        <p>{statusMessage}</p>
+        {state?.lastMessage && <p>{state.lastMessage}</p>}
         {error && <p className="error">Error: {error}</p>}
-      </section>
+      </footer>
     </main>
+  );
+}
+
+type MetricProps = {
+  label: string;
+  value: number;
+  variant: "life" | "knowledge" | "courage" | "focus" | "score";
+};
+
+function Metric({ label, value, variant }: MetricProps) {
+  return (
+    <div className={`metric metric-${variant}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- redesign frontend UX into a guided 3-step flow (prepare, start/resume, play)
- add clearer action selection UX with contextual controls for challenge/item actions
- add gameplay HUD with progress bar and visual stat cards
- persist last session id in localStorage for resume continuity
- update root/frontend README to document the new flow

## Validation
- npm run lint (apps/frontend)
- npm run build (apps/frontend)
- mvn test (apps/backend)