### PR TITLE
feat: pedagogic autoplay, telemetry, e2e and release flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Tipo de cambio
+- [ ] feature
+- [ ] hotfix
+- [ ] release
+
+## Rama objetivo (GitFlow)
+- [ ] `develop` (cambios normales)
+- [ ] `main` (solo release/hotfix aprobado)
+
+## Checklist
+- [ ] Tests backend (`mvn test`) en verde
+- [ ] Build/lint frontend en verde
+- [ ] README/docs actualizados si hubo cambios de UX/flujo
+- [ ] Sin artefactos de build ni archivos temporales
+- [ ] Compatibilidad de guardado preservada o migracion documentada
+
+## Validacion ejecutada
+Describe comandos y resultados relevantes.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,28 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  frontend-e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install chromium --with-deps
+
+      - name: E2E
+        run: npm run test:e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (ej: v3.2.0)"
+        required: true
+        type: string
+
+jobs:
+  build-desktop:
+    runs-on: windows-latest
+    env:
+      APP_NAME: AutoBookQuest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            "value=${{ inputs.version }}" >> $env:GITHUB_OUTPUT
+          } else {
+            "value=${{ github.ref_name }}" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: apps/frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Sync frontend assets to backend static
+        shell: pwsh
+        run: |
+          Remove-Item -Recurse -Force "apps/backend/src/main/resources/static/*" -ErrorAction SilentlyContinue
+          Copy-Item -Recurse -Force "apps/frontend/dist/*" "apps/backend/src/main/resources/static/"
+
+      - name: Package backend jar
+        working-directory: apps/backend
+        run: mvn -B clean package -DskipTests
+
+      - name: Build desktop app image
+        id: package
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.value }}".TrimStart('v')
+          $jar = Get-ChildItem "apps/backend/target/autobook-adventure-*.jar" | Select-Object -First 1
+          if (-not $jar) { throw "Jar no encontrado en apps/backend/target" }
+          New-Item -ItemType Directory -Force -Path ".jpackage-input" | Out-Null
+          Copy-Item $jar.FullName ".jpackage-input/$($jar.Name)" -Force
+          New-Item -ItemType Directory -Force -Path "dist" | Out-Null
+          jpackage `
+            --type app-image `
+            --name "$env:APP_NAME" `
+            --dest "dist" `
+            --input ".jpackage-input" `
+            --main-jar "$($jar.Name)" `
+            --main-class "org.springframework.boot.loader.launch.JarLauncher" `
+            --app-version "$version" `
+            --java-options "-Dserver.port=8080"
+          "app_dir=dist/$env:APP_NAME" >> $env:GITHUB_OUTPUT
+
+      - name: Optional code signing
+        if: ${{ secrets.WINDOWS_CERT_BASE64 != '' && secrets.WINDOWS_CERT_PASSWORD != '' }}
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          [IO.File]::WriteAllBytes("codesign.pfx", [Convert]::FromBase64String("${{ secrets.WINDOWS_CERT_BASE64 }}"))
+          $exe = Get-ChildItem "${{ steps.package.outputs.app_dir }}" -Recurse -Filter "*.exe" | Select-Object -First 1
+          if ($exe) {
+            signtool sign /f codesign.pfx /p "${{ secrets.WINDOWS_CERT_PASSWORD }}" /tr http://timestamp.digicert.com /td sha256 /fd sha256 $exe.FullName
+          }
+
+      - name: Zip desktop distribution
+        id: archive
+        shell: pwsh
+        run: |
+          $zipName = "AutoBookQuest-win64.zip"
+          Compress-Archive -Path "${{ steps.package.outputs.app_dir }}/*" -DestinationPath "dist/$zipName" -Force
+          "zip_path=dist/$zipName" >> $env:GITHUB_OUTPUT
+
+      - name: Create update manifest
+        shell: pwsh
+        run: |
+          $tag = "${{ steps.version.outputs.value }}"
+          $url = "https://github.com/${{ github.repository }}/releases/download/$tag/AutoBookQuest-win64.zip"
+          $manifest = @{
+            version = $tag
+            publishedAt = (Get-Date).ToString("o")
+            channel = "stable"
+            assets = @(
+              @{
+                platform = "win64"
+                url = $url
+              }
+            )
+          } | ConvertTo-Json -Depth 4
+          Set-Content -Path "dist/latest.json" -Value $manifest -Encoding UTF8
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.value }}
+          target_commitish: main
+          generate_release_notes: true
+          files: |
+            ${{ steps.archive.outputs.zip_path }}
+            dist/latest.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /apps/backend/target/
 /apps/frontend/dist/
 /apps/frontend/node_modules/
+/apps/frontend/playwright-report/
+/apps/frontend/test-results/
 
 # Runtime data
 /.autobook-data/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Ser una referencia abierta en tecnologia educativa hispanohablante para aprendiz
 - `docs`: arquitectura, desktop, roadmap y backlog.
 - `scripts`: empaquetado desktop.
 
+## GitFlow operativo
+- Rama de integracion: `develop`.
+- Rama de produccion: `main`.
+- Features siempre por `feature/* -> develop`.
+- Releases por `release/* -> main` con tag `vX.Y.Z`.
+- Guia detallada: `docs/GITFLOW.md`.
+
 ## Inicio rapido local
 ```bash
 # Terminal 1
@@ -40,6 +47,7 @@ Abrir: `http://localhost:5173`
 - Release publico actual: `v3.1.0`
 - Incluye `AutoBookQuest-win64.zip` (portable con `AutoBookQuest.exe`).
 - Para instalador `.exe` tipo setup con `jpackage`, se requiere WiX v3 instalado.
+- El workflow `release` publica tambien `latest.json` para auto-update.
 
 ## Calidad
 - Backend: `mvn test`

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/GameController.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/GameController.java
@@ -1,11 +1,15 @@
 package com.juegodefinitivo.autobook.api;
 
 import com.juegodefinitivo.autobook.api.dto.ActionRequest;
+import com.juegodefinitivo.autobook.api.dto.AutoplayRequest;
 import com.juegodefinitivo.autobook.api.dto.BookView;
 import com.juegodefinitivo.autobook.api.dto.GameStateResponse;
 import com.juegodefinitivo.autobook.api.dto.ImportBookRequest;
 import com.juegodefinitivo.autobook.api.dto.StartGameRequest;
+import com.juegodefinitivo.autobook.api.dto.TelemetryEventRequest;
+import com.juegodefinitivo.autobook.api.dto.TelemetrySummaryResponse;
 import com.juegodefinitivo.autobook.service.GameFacadeService;
+import com.juegodefinitivo.autobook.service.TelemetryService;
 import jakarta.annotation.PostConstruct;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,9 +30,11 @@ import java.util.Map;
 public class GameController {
 
     private final GameFacadeService service;
+    private final TelemetryService telemetryService;
 
-    public GameController(GameFacadeService service) {
+    public GameController(GameFacadeService service, TelemetryService telemetryService) {
         this.service = service;
+        this.telemetryService = telemetryService;
     }
 
     @PostConstruct
@@ -64,6 +70,23 @@ public class GameController {
     @PostMapping("/game/{sessionId}/action")
     public GameStateResponse action(@PathVariable String sessionId, @RequestBody ActionRequest request) {
         return service.applyAction(sessionId, request.action(), request.answerIndex(), request.itemId());
+    }
+
+    @PostMapping("/game/{sessionId}/autoplay")
+    public GameStateResponse autoplay(@PathVariable String sessionId, @RequestBody(required = false) AutoplayRequest request) {
+        AutoplayRequest safeRequest = request == null ? new AutoplayRequest(null, null, null) : request;
+        return service.applyAutoplay(sessionId, safeRequest.ageBand(), safeRequest.readingLevel(), safeRequest.maxSteps());
+    }
+
+    @PostMapping("/telemetry/events")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public void telemetry(@RequestBody TelemetryEventRequest request) {
+        telemetryService.record(request);
+    }
+
+    @GetMapping("/telemetry/summary")
+    public TelemetrySummaryResponse telemetrySummary() {
+        return telemetryService.summary();
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/AutoplayRequest.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/AutoplayRequest.java
@@ -1,0 +1,5 @@
+package com.juegodefinitivo.autobook.api.dto;
+
+public record AutoplayRequest(String ageBand, String readingLevel, Integer maxSteps) {
+}
+

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/TelemetryEventRequest.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/TelemetryEventRequest.java
@@ -1,0 +1,13 @@
+package com.juegodefinitivo.autobook.api.dto;
+
+import java.util.Map;
+
+public record TelemetryEventRequest(
+        String sessionId,
+        String eventName,
+        String stage,
+        Long elapsedMs,
+        Map<String, String> metadata
+) {
+}
+

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/TelemetrySummaryResponse.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/TelemetrySummaryResponse.java
@@ -1,0 +1,11 @@
+package com.juegodefinitivo.autobook.api.dto;
+
+import java.util.Map;
+
+public record TelemetrySummaryResponse(
+        long totalEvents,
+        Map<String, Long> byEvent,
+        Map<String, Long> byStage
+) {
+}
+

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/service/AutoplayService.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/service/AutoplayService.java
@@ -1,0 +1,114 @@
+package com.juegodefinitivo.autobook.service;
+
+import com.juegodefinitivo.autobook.domain.GameSession;
+import com.juegodefinitivo.autobook.engine.PlayerAction;
+import com.juegodefinitivo.autobook.narrative.NarrativeScene;
+import com.juegodefinitivo.autobook.narrative.SceneEventType;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+import java.util.Random;
+
+@Service
+public class AutoplayService {
+
+    private final Random random;
+
+    public AutoplayService(Random random) {
+        this.random = random;
+    }
+
+    public PlannedTurn planTurn(GameSession session, NarrativeScene scene, String ageBandInput, String readingLevelInput) {
+        AgeBand ageBand = AgeBand.from(ageBandInput);
+        ReadingLevel readingLevel = ReadingLevel.from(readingLevelInput);
+
+        if (session.getLife() <= 40 && session.getInventory().getOrDefault("potion_small", 0) > 0) {
+            return new PlannedTurn(PlayerAction.USE_ITEM, false, "potion_small", "Auto: usa pocion para estabilizar vida.");
+        }
+
+        PlayerAction action = switch (scene.eventType()) {
+            case REST -> PlayerAction.TALK;
+            case DISCOVERY -> PlayerAction.EXPLORE;
+            case CHALLENGE -> PlayerAction.CHALLENGE;
+            case DIALOGUE -> readingLevel == ReadingLevel.ADVANCED ? PlayerAction.EXPLORE : PlayerAction.TALK;
+            case BATTLE -> pickBattleAction(ageBand, readingLevel, session);
+        };
+
+        boolean challengeCorrect = false;
+        if (action == PlayerAction.CHALLENGE) {
+            challengeCorrect = shouldAnswerCorrect(ageBand, readingLevel);
+        }
+
+        return new PlannedTurn(action, challengeCorrect, null, "Auto: " + action.name() + " en evento " + scene.eventType().name() + ".");
+    }
+
+    private PlayerAction pickBattleAction(AgeBand ageBand, ReadingLevel readingLevel, GameSession session) {
+        if (ageBand == AgeBand.EARLY || readingLevel == ReadingLevel.BEGINNER) {
+            if (session.getInventory().getOrDefault("potion_small", 0) > 0 && session.getLife() < 55) {
+                return PlayerAction.USE_ITEM;
+            }
+            return PlayerAction.TALK;
+        }
+        return random.nextInt(100) < 60 ? PlayerAction.CHALLENGE : PlayerAction.EXPLORE;
+    }
+
+    private boolean shouldAnswerCorrect(AgeBand ageBand, ReadingLevel readingLevel) {
+        int accuracy = switch (readingLevel) {
+            case BEGINNER -> 55;
+            case INTERMEDIATE -> 75;
+            case ADVANCED -> 90;
+        };
+        if (ageBand == AgeBand.EARLY) {
+            accuracy -= 10;
+        }
+        if (ageBand == AgeBand.TEEN) {
+            accuracy += 5;
+        }
+        int roll = random.nextInt(100);
+        return roll < Math.max(20, Math.min(95, accuracy));
+    }
+
+    private enum AgeBand {
+        EARLY,
+        MIDDLE,
+        TEEN;
+
+        static AgeBand from(String value) {
+            if (value == null || value.isBlank()) {
+                return MIDDLE;
+            }
+            String normalized = value.trim().toLowerCase(Locale.ROOT);
+            if (normalized.contains("6") || normalized.contains("7") || normalized.contains("8") || normalized.contains("early")) {
+                return EARLY;
+            }
+            if (normalized.contains("13") || normalized.contains("teen")) {
+                return TEEN;
+            }
+            return MIDDLE;
+        }
+    }
+
+    private enum ReadingLevel {
+        BEGINNER,
+        INTERMEDIATE,
+        ADVANCED;
+
+        static ReadingLevel from(String value) {
+            if (value == null || value.isBlank()) {
+                return INTERMEDIATE;
+            }
+            String normalized = value.trim().toLowerCase(Locale.ROOT);
+            if (normalized.startsWith("beg")) {
+                return BEGINNER;
+            }
+            if (normalized.startsWith("adv")) {
+                return ADVANCED;
+            }
+            return INTERMEDIATE;
+        }
+    }
+
+    public record PlannedTurn(PlayerAction action, boolean challengeCorrect, String itemId, String rationale) {
+    }
+}
+

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/service/TelemetryService.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/service/TelemetryService.java
@@ -1,0 +1,81 @@
+package com.juegodefinitivo.autobook.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.juegodefinitivo.autobook.api.dto.TelemetryEventRequest;
+import com.juegodefinitivo.autobook.api.dto.TelemetrySummaryResponse;
+import com.juegodefinitivo.autobook.config.AppConfig;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+@Service
+public class TelemetryService {
+
+    private final Path eventsDir;
+    private final ObjectMapper objectMapper;
+    private final ConcurrentHashMap<String, LongAdder> byEvent = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, LongAdder> byStage = new ConcurrentHashMap<>();
+
+    public TelemetryService(AppConfig config, ObjectMapper objectMapper) {
+        this.eventsDir = config.dataDir().resolve("telemetry");
+        this.objectMapper = objectMapper;
+    }
+
+    public void record(TelemetryEventRequest event) {
+        if (event == null || event.eventName() == null || event.eventName().isBlank()) {
+            throw new IllegalArgumentException("eventName es requerido.");
+        }
+
+        String eventName = event.eventName().trim();
+        String stage = event.stage() == null || event.stage().isBlank() ? "unknown" : event.stage().trim();
+        byEvent.computeIfAbsent(eventName, key -> new LongAdder()).increment();
+        byStage.computeIfAbsent(stage, key -> new LongAdder()).increment();
+
+        Map<String, Object> line = new LinkedHashMap<>();
+        line.put("timestamp", Instant.now().toString());
+        line.put("sessionId", event.sessionId());
+        line.put("eventName", eventName);
+        line.put("stage", stage);
+        line.put("elapsedMs", event.elapsedMs());
+        line.put("metadata", event.metadata() == null ? Map.of() : event.metadata());
+        append(line);
+    }
+
+    public TelemetrySummaryResponse summary() {
+        return new TelemetrySummaryResponse(totalEvents(), snapshot(byEvent), snapshot(byStage));
+    }
+
+    private long totalEvents() {
+        return byEvent.values().stream().mapToLong(LongAdder::sum).sum();
+    }
+
+    private Map<String, Long> snapshot(ConcurrentHashMap<String, LongAdder> source) {
+        Map<String, Long> out = new LinkedHashMap<>();
+        source.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> out.put(entry.getKey(), entry.getValue().sum()));
+        return out;
+    }
+
+    private void append(Map<String, Object> payload) {
+        try {
+            Files.createDirectories(eventsDir);
+            Path file = eventsDir.resolve("events-" + LocalDate.now() + ".jsonl");
+            String line = objectMapper.writeValueAsString(payload) + System.lineSeparator();
+            Files.writeString(file, line, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException ex) {
+            throw new IllegalStateException("No se pudo registrar telemetria.", ex);
+        }
+    }
+}
+

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/GameFacadeServiceTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/GameFacadeServiceTest.java
@@ -53,4 +53,17 @@ class GameFacadeServiceTest {
                 () -> facade.getState("missing-session"));
         assertEquals("Sesion no encontrada.", ex.getMessage());
     }
+
+    @Test
+    void shouldAdvanceGameWithAutoplay() {
+        facade.bootstrapSamples();
+        var books = facade.listBooks();
+        GameStateResponse state = facade.startGame("Sofia", books.get(0).path());
+
+        GameStateResponse updated = facade.applyAutoplay(state.sessionId(), "9-12", "intermediate", 4);
+
+        assertTrue(updated.score() >= state.score());
+        assertNotNull(updated.lastMessage());
+        assertTrue(updated.lastMessage().contains("auto-steps"));
+    }
 }

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -26,7 +26,17 @@ npm run build
    - `Explorar`
    - `Resolver reto` (seleccion de respuesta)
    - `Usar item` (seleccion de inventario)
+4. `Modo Auto Pedagogico`: ejecuta pasos automáticos configurando edad, nivel lector y pasos.
 
 ## Estado de sesion
 - El frontend guarda el ultimo `sessionId` en `localStorage` con la clave `autobook:lastSessionId`.
 - Al recargar la pagina, ese `sessionId` aparece automaticamente en el campo de reanudacion.
+
+## Telemetria UX
+- El frontend reporta eventos de setup/juego al backend (`/api/telemetry/events`).
+- Resumen visible en UI (`Telemetria UX`) y disponible por API (`/api/telemetry/summary`).
+
+## E2E
+```bash
+npm run test:e2e
+```

--- a/apps/frontend/e2e/guided-flow.spec.ts
+++ b/apps/frontend/e2e/guided-flow.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+test("guided flow supports start, manual action and autoplay with telemetry", async ({ page }) => {
+  let currentSceneIndex = 0;
+  let score = 0;
+  let totalEvents = 0;
+  const sessionId = "session-e2e-1";
+
+  await page.route("**/api/books", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        json: [{ title: "Libro Demo", path: "C:/books/demo.txt", format: "txt" }],
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route("**/api/game/start", async (route) => {
+    currentSceneIndex = 0;
+    score = 0;
+    await route.fulfill({
+      json: gameState(sessionId, score, currentSceneIndex, "Partida iniciada."),
+    });
+  });
+
+  await page.route("**/api/game/**/action", async (route) => {
+    currentSceneIndex += 1;
+    score += 5;
+    await route.fulfill({
+      json: gameState(sessionId, score, currentSceneIndex, "Accion manual aplicada."),
+    });
+  });
+
+  await page.route("**/api/game/**/autoplay", async (route) => {
+    currentSceneIndex += 2;
+    score += 12;
+    await route.fulfill({
+      json: gameState(sessionId, score, currentSceneIndex, "Modo auto aplicado. (auto-steps=2)"),
+    });
+  });
+
+  await page.route("**/api/telemetry/events", async (route) => {
+    totalEvents += 1;
+    await route.fulfill({ status: 202 });
+  });
+
+  await page.route("**/api/telemetry/summary", async (route) => {
+    await route.fulfill({
+      json: {
+        totalEvents,
+        byEvent: { action_executed: Math.min(totalEvents, 1), autoplay_run: totalEvents > 1 ? 1 : 0 },
+        byStage: { play: totalEvents, setup: 0 },
+      },
+    });
+  });
+
+  await page.goto("/");
+  await page.getByTestId("start-game").click();
+  await expect(page.getByText("Jugador:")).toContainText("Aventurero");
+
+  await page.getByTestId("execute-action").click();
+  await expect(page.getByText("Puntaje").locator("..").getByText("5")).toBeVisible();
+
+  await page.getByTestId("run-autoplay").click();
+  await expect(page.getByText("Modo auto aplicado").first()).toBeVisible();
+  await expect(page.getByTestId("telemetry-total")).toHaveText("3");
+});
+
+function gameState(sessionId: string, score: number, index: number, lastMessage: string) {
+  return {
+    sessionId,
+    playerName: "Aventurero",
+    bookTitle: "Libro Demo",
+    completed: false,
+    life: 95,
+    knowledge: 6,
+    courage: 4,
+    focus: 5,
+    score,
+    correctAnswers: 1,
+    discoveries: 1,
+    inventory: { potion_small: 1 },
+    quests: [
+      {
+        id: "reader",
+        title: "Cronista aprendiz",
+        description: "Responde correctamente 3 retos de lectura.",
+        completed: false,
+      },
+    ],
+    currentScene: {
+      index,
+      total: 8,
+      title: `Escena ${index + 1}`,
+      text: "Texto de prueba",
+      eventType: "DIALOGUE",
+      npc: "Mentor",
+      challenge: {
+        prompt: "Pregunta?",
+        options: ["A", "B", "C", "D"],
+      },
+    },
+    lastMessage,
+  };
+}

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.56.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -1007,6 +1008,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2768,6 +2785,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,13 +7,15 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.1",
     "@eslint/js": "^9.39.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run build && npm run preview -- --host 127.0.0.1 --port 4173",
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});
+

--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -304,6 +304,25 @@ button:disabled {
   background: #fff;
 }
 
+.autoplay-panel {
+  margin-top: 0.9rem;
+  border: 1px solid #d4dde1;
+  border-radius: 12px;
+  padding: 0.8rem;
+  background: linear-gradient(120deg, #fff8e7 0%, #fff 100%);
+}
+
+.autoplay-panel h3 {
+  margin: 0 0 0.6rem;
+}
+
+.auto-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 0.6rem;
+}
+
 .actions-panel h3 {
   margin: 0 0 0.6rem;
 }
@@ -349,7 +368,7 @@ button:disabled {
 .bottom-grid {
   margin-top: 0.9rem;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.75rem;
 }
 
@@ -419,6 +438,10 @@ button:disabled {
   .stats-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+
+  .bottom-grid {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 @media (max-width: 760px) {
@@ -436,6 +459,10 @@ button:disabled {
   }
 
   .action-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .auto-grid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -43,3 +43,9 @@ export type GameState = {
   currentScene: SceneView | null;
   lastMessage: string;
 };
+
+export type TelemetrySummary = {
+  totalEvents: number;
+  byEvent: Record<string, number>;
+  byStage: Record<string, number>;
+};

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -12,6 +12,12 @@ powershell -ExecutionPolicy Bypass -File scripts/package-exe.ps1
 ## Resultado
 - Con WiX: genera instalador `.exe` en `dist/`.
 - Sin WiX: fallback automatico a `app-image` portable en `dist/`.
+- En pipeline de release: se publica `AutoBookQuest-win64.zip` + `latest.json` para auto-update.
+
+## Firma de binarios en CI
+- El workflow `.github/workflows/release.yml` firma opcionalmente los `.exe` si existen secretos:
+  - `WINDOWS_CERT_BASE64`
+  - `WINDOWS_CERT_PASSWORD`
 
 ## Nota tecnica
 El script crea un input temporal con **solo el jar final** para evitar incluir artefactos de compilacion no deseados.

--- a/docs/GITFLOW.md
+++ b/docs/GITFLOW.md
@@ -1,0 +1,22 @@
+# GitFlow del proyecto
+
+## Ramas
+- `main`: produccion. Solo recibe merges de release o hotfix.
+- `develop`: integracion continua. Todas las features se integran aqui primero.
+- `feature/*`: trabajo incremental por funcionalidad.
+- `hotfix/*`: correcciones urgentes partiendo de `main`.
+- `release/*`: estabilizacion de version antes de publicar en `main`.
+
+## Flujo recomendado
+1. Crear feature desde `develop`.
+2. Abrir PR `feature/* -> develop`.
+3. Validar CI completo (backend + frontend + E2E).
+4. Para versionar: crear `release/x.y.z` desde `develop`.
+5. PR `release/* -> main`, merge y tag `vX.Y.Z`.
+6. Ejecutar workflow `release` para publicar artefactos desktop y `latest.json`.
+7. Back-merge de `main` hacia `develop` si hubo ajustes de release.
+
+## Convencion de push
+- Push de trabajo diario: `develop` y `feature/*`.
+- Push directo a `main`: no permitido salvo mantenimiento de release/hotfix.
+

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,5 +1,11 @@
 # Next Steps (Prioritized)
 
+0. Ya implementado en esta iteracion
+- E2E browser tests con Playwright.
+- Modo auto pedagogico configurable por edad/nivel.
+- Telemetria UX basica con resumen por evento/etapa.
+- Pipeline de release con artefacto desktop + `latest.json`.
+
 1. Persistencia productiva
 - Migrar sesiones/inventario a PostgreSQL con Flyway.
 - Agregar migraciones versionadas y estrategia de respaldo.
@@ -20,11 +26,9 @@
 - Export de reportes CSV.
 
 5. Plataforma
-- Frontend tests (Vitest + Testing Library).
-- E2E browser tests (Playwright).
+- Frontend tests unitarios (Vitest + Testing Library).
 - Publicar imagen Docker para backend.
 
 6. Desktop distribucion
-- Pipeline CI para empaquetado multiplataforma.
 - Instalador `.exe` oficial cuando WiX este disponible en runner.
-- Firma de binarios para confianza del usuario.
+- Activar firma obligatoria de binarios en release.


### PR DESCRIPTION
## Summary
- add backend autoplay endpoint configurable by age band and reading level
- add backend telemetry ingestion and summary endpoints
- integrate frontend telemetry and new Auto Pedagogic mode controls
- add Playwright E2E test suite and CI job
- add release workflow with desktop zip, latest.json auto-update manifest and optional code signing
- document GitFlow and update UX/release docs

## Validation
- apps/backend: mvn test
- apps/frontend: npm run lint
- apps/frontend: npm run build
- apps/frontend: npm run test:e2e