### PR TITLE
feat(backend): normalize imported book text before scene parsing

### DIFF
--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/AppBeansConfig.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/AppBeansConfig.java
@@ -6,6 +6,7 @@ import com.juegodefinitivo.autobook.engine.GameEngineService;
 import com.juegodefinitivo.autobook.ingest.BookCatalogService;
 import com.juegodefinitivo.autobook.ingest.BookImportService;
 import com.juegodefinitivo.autobook.ingest.BookLoaderService;
+import com.juegodefinitivo.autobook.ingest.BookTextNormalizer;
 import com.juegodefinitivo.autobook.ingest.ExtractorResolver;
 import com.juegodefinitivo.autobook.ingest.PdfTextExtractor;
 import com.juegodefinitivo.autobook.ingest.TxtTextExtractor;
@@ -55,8 +56,8 @@ public class AppBeansConfig {
     }
 
     @Bean
-    public BookLoaderService bookLoaderService(ExtractorResolver resolver, BookParser parser) {
-        return new BookLoaderService(resolver, parser);
+    public BookLoaderService bookLoaderService(ExtractorResolver resolver, BookTextNormalizer normalizer, BookParser parser) {
+        return new BookLoaderService(resolver, normalizer, parser);
     }
 
     @Bean

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/ingest/BookLoaderService.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/ingest/BookLoaderService.java
@@ -9,16 +9,19 @@ import java.util.List;
 public class BookLoaderService {
 
     private final ExtractorResolver resolver;
+    private final BookTextNormalizer normalizer;
     private final BookParser parser;
 
-    public BookLoaderService(ExtractorResolver resolver, BookParser parser) {
+    public BookLoaderService(ExtractorResolver resolver, BookTextNormalizer normalizer, BookParser parser) {
         this.resolver = resolver;
+        this.normalizer = normalizer;
         this.parser = parser;
     }
 
     public List<Scene> loadScenes(Path path, int maxChars, int linesPerChunk) {
         DocumentTextExtractor extractor = resolver.resolve(path);
         String rawText = extractor.extract(path);
-        return parser.parseText(rawText, maxChars, linesPerChunk);
+        String cleanText = normalizer.normalize(rawText);
+        return parser.parseText(cleanText, maxChars, linesPerChunk);
     }
 }

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/ingest/BookTextNormalizer.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/ingest/BookTextNormalizer.java
@@ -1,0 +1,227 @@
+package com.juegodefinitivo.autobook.ingest;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Component
+public class BookTextNormalizer {
+
+    private static final Pattern PAGE_NUMBER_LINE = Pattern.compile("^(?:p(?:ag(?:ina)?)?\\.?\\s*)?[0-9ivxlcdm]{1,8}$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern MULTI_SPACE = Pattern.compile("\\s+");
+
+    public String normalize(String rawText) {
+        if (rawText == null || rawText.isBlank()) {
+            return "";
+        }
+
+        String normalizedLineBreaks = rawText
+                .replace("\uFEFF", "")
+                .replace("\r\n", "\n")
+                .replace('\r', '\n');
+
+        List<List<String>> pages = splitIntoPages(normalizedLineBreaks);
+        HeaderFooterProfile profile = buildProfile(pages);
+
+        List<String> resultLines = new ArrayList<>();
+        for (int p = 0; p < pages.size(); p++) {
+            List<String> filtered = filterNoise(pages.get(p), profile);
+            List<String> merged = mergeHyphenatedBreaks(filtered);
+            if (!resultLines.isEmpty()) {
+                resultLines.add("");
+            }
+            resultLines.addAll(merged);
+        }
+
+        return collapseBlankRuns(resultLines).trim();
+    }
+
+    private List<List<String>> splitIntoPages(String text) {
+        String[] rawPages = text.split("\\f+");
+        List<List<String>> pages = new ArrayList<>();
+        for (String page : rawPages) {
+            String[] rawLines = page.split("\n");
+            List<String> lines = new ArrayList<>();
+            for (String rawLine : rawLines) {
+                String line = compact(rawLine);
+                lines.add(line);
+            }
+            pages.add(lines);
+        }
+        if (pages.isEmpty()) {
+            pages.add(List.of());
+        }
+        return pages;
+    }
+
+    private HeaderFooterProfile buildProfile(List<List<String>> pages) {
+        Map<String, Integer> headerCount = new HashMap<>();
+        Map<String, Integer> footerCount = new HashMap<>();
+
+        for (List<String> page : pages) {
+            String header = firstNonBlank(page);
+            String footer = lastNonBlank(page);
+            if (isHeaderFooterCandidate(header)) {
+                headerCount.merge(signature(header), 1, Integer::sum);
+            }
+            if (isHeaderFooterCandidate(footer)) {
+                footerCount.merge(signature(footer), 1, Integer::sum);
+            }
+        }
+
+        return new HeaderFooterProfile(headerCount, footerCount, Math.max(2, pages.size() / 3));
+    }
+
+    private List<String> filterNoise(List<String> page, HeaderFooterProfile profile) {
+        List<String> output = new ArrayList<>();
+        String header = firstNonBlank(page);
+        String footer = lastNonBlank(page);
+        String headerSig = signature(header);
+        String footerSig = signature(footer);
+
+        for (int i = 0; i < page.size(); i++) {
+            String line = page.get(i);
+            if (line.isBlank()) {
+                output.add("");
+                continue;
+            }
+            if (PAGE_NUMBER_LINE.matcher(line).matches()) {
+                continue;
+            }
+            if (i == indexOfFirstNonBlank(page)
+                    && profile.headerCount().getOrDefault(headerSig, 0) >= profile.minRepetitions()) {
+                continue;
+            }
+            if (i == indexOfLastNonBlank(page)
+                    && profile.footerCount().getOrDefault(footerSig, 0) >= profile.minRepetitions()) {
+                continue;
+            }
+            output.add(line);
+        }
+        return output;
+    }
+
+    private List<String> mergeHyphenatedBreaks(List<String> lines) {
+        List<String> merged = new ArrayList<>();
+        int i = 0;
+        while (i < lines.size()) {
+            String current = lines.get(i);
+            if (current.isBlank()) {
+                merged.add("");
+                i++;
+                continue;
+            }
+            if (current.endsWith("-") && i + 1 < lines.size()) {
+                String next = lines.get(i + 1);
+                if (!next.isBlank() && startsWithLowercase(next)) {
+                    merged.add(current.substring(0, current.length() - 1) + next);
+                    i += 2;
+                    continue;
+                }
+            }
+            merged.add(current);
+            i++;
+        }
+        return merged;
+    }
+
+    private String collapseBlankRuns(List<String> lines) {
+        StringBuilder out = new StringBuilder();
+        boolean lastBlank = false;
+        for (String line : lines) {
+            if (line.isBlank()) {
+                if (!lastBlank) {
+                    out.append('\n');
+                }
+                lastBlank = true;
+            } else {
+                if (out.length() > 0 && !lastBlank) {
+                    out.append('\n');
+                }
+                out.append(line);
+                lastBlank = false;
+            }
+        }
+        return out.toString();
+    }
+
+    private String compact(String value) {
+        if (value == null) {
+            return "";
+        }
+        return MULTI_SPACE.matcher(value.trim()).replaceAll(" ");
+    }
+
+    private boolean startsWithLowercase(String line) {
+        int codePoint = line.codePointAt(0);
+        return Character.isLetter(codePoint) && Character.isLowerCase(codePoint);
+    }
+
+    private boolean isHeaderFooterCandidate(String line) {
+        if (line == null || line.isBlank()) {
+            return false;
+        }
+        int length = line.length();
+        return length >= 6 && length <= 90;
+    }
+
+    private String signature(String line) {
+        if (line == null) {
+            return "";
+        }
+        return line
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\d+", "#")
+                .replaceAll("[^\\p{L}# ]", "")
+                .trim();
+    }
+
+    private String firstNonBlank(List<String> lines) {
+        for (String line : lines) {
+            if (!line.isBlank()) {
+                return line;
+            }
+        }
+        return "";
+    }
+
+    private String lastNonBlank(List<String> lines) {
+        for (int i = lines.size() - 1; i >= 0; i--) {
+            if (!lines.get(i).isBlank()) {
+                return lines.get(i);
+            }
+        }
+        return "";
+    }
+
+    private int indexOfFirstNonBlank(List<String> lines) {
+        for (int i = 0; i < lines.size(); i++) {
+            if (!lines.get(i).isBlank()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int indexOfLastNonBlank(List<String> lines) {
+        for (int i = lines.size() - 1; i >= 0; i--) {
+            if (!lines.get(i).isBlank()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private record HeaderFooterProfile(
+            Map<String, Integer> headerCount,
+            Map<String, Integer> footerCount,
+            int minRepetitions
+    ) {
+    }
+}
+

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/BookTextNormalizerTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/BookTextNormalizerTest.java
@@ -1,0 +1,51 @@
+package com.juegodefinitivo.autobook;
+
+import com.juegodefinitivo.autobook.ingest.BookTextNormalizer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BookTextNormalizerTest {
+
+    private final BookTextNormalizer normalizer = new BookTextNormalizer();
+
+    @Test
+    void shouldRemoveRepeatedHeadersFootersAndPageNumbers() {
+        String raw = """
+                El Caballero de la Armadura Oxidada
+                Capitulo uno inicia aqui.
+                1
+                \f
+                El Caballero de la Armadura Oxidada
+                Continua la aventura.
+                2
+                \f
+                El Caballero de la Armadura Oxidada
+                Cierre del capitulo.
+                3
+                """;
+
+        String clean = normalizer.normalize(raw);
+
+        assertFalse(clean.contains("El Caballero de la Armadura Oxidada"));
+        assertFalse(clean.contains("\n1\n"));
+        assertFalse(clean.contains("\n2\n"));
+        assertTrue(clean.contains("Capitulo uno inicia aqui."));
+        assertTrue(clean.contains("Continua la aventura."));
+        assertTrue(clean.contains("Cierre del capitulo."));
+    }
+
+    @Test
+    void shouldMergeHyphenatedLineBreaks() {
+        String raw = """
+                Esta es una histo-
+                ria para ninos.
+                """;
+
+        String clean = normalizer.normalize(raw);
+
+        assertTrue(clean.contains("historia para ninos."));
+    }
+}
+

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/EndToEndFlowTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/EndToEndFlowTest.java
@@ -6,6 +6,7 @@ import com.juegodefinitivo.autobook.engine.BookParser;
 import com.juegodefinitivo.autobook.engine.GameEngineService;
 import com.juegodefinitivo.autobook.engine.PlayerAction;
 import com.juegodefinitivo.autobook.ingest.BookLoaderService;
+import com.juegodefinitivo.autobook.ingest.BookTextNormalizer;
 import com.juegodefinitivo.autobook.ingest.ExtractorResolver;
 import com.juegodefinitivo.autobook.ingest.TxtTextExtractor;
 import com.juegodefinitivo.autobook.narrative.DialogueService;
@@ -28,6 +29,7 @@ class EndToEndFlowTest {
 
         BookLoaderService loader = new BookLoaderService(
                 new ExtractorResolver(new TxtTextExtractor(), path -> ""),
+                new BookTextNormalizer(),
                 new BookParser()
         );
         NarrativeBuilder builder = new NarrativeBuilder(new AutoQuestionService(new Random(2)), new Random(2));

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -5,6 +5,7 @@
 - Modo auto pedagogico configurable por edad/nivel.
 - Telemetria UX basica con resumen por evento/etapa.
 - Pipeline de release con artefacto desktop + `latest.json`.
+- Pipeline base de normalizacion de texto (headers/footers repetidos, numeros de pagina, guiones de corte).
 
 1. Persistencia productiva
 - Migrar sesiones/inventario a PostgreSQL con Flyway.
@@ -16,7 +17,7 @@
 - Agregar rate limiting basico por IP/sesion.
 
 3. Calidad de narrativa
-- Mejorar extraccion semantica de personajes/lugares.
+- Mejorar extraccion semantica de personajes/lugares sobre texto ya normalizado.
 - Añadir continuidad narrativa entre escenas.
 - Incorporar niveles de dificultad por edad.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9,13 +9,14 @@
 
 ## Product
 - [ ] Guardado multiusuario en DB
-- [ ] Dificultad adaptativa por edad
+- [x] Dificultad adaptativa base por edad (modo auto)
 - [ ] Modo docente con analitica
 - [ ] Internacionalizacion es/en/pt
 - [ ] Accesibilidad avanzada (alto contraste, narracion)
+- [x] Pipeline base de normalizacion de texto para PDF/TXT
 
 ## Engineering
 - [ ] Contratos OpenAPI para endpoints
 - [ ] Tests frontend unitarios
-- [ ] Tests E2E de interfaz
+- [x] Tests E2E de interfaz
 - [ ] Observabilidad (logs estructurados + metricas)


### PR DESCRIPTION
## Summary
- add BookTextNormalizer to clean raw TXT/PDF extracted text
- remove repeated headers/footers and page-number lines
- merge hyphenated line breaks from PDF extraction
- integrate normalizer in BookLoaderService before BookParser
- add dedicated unit tests for normalization and update end-to-end wiring test
- update docs/TODO.md and docs/NEXT_STEPS.md

## Validation
- apps/backend: mvn test
- apps/frontend: npm run lint
- apps/frontend: npm run build