### PR TITLE
feat(learning): narrative memory graph foundation and adaptive reading quality track

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Abrir: `http://localhost:5173`
 - `docs/PROJECT_CHARTER.md`
 - `docs/ROADMAP.md`
 - `docs/NEXT_STEPS.md`
+- `docs/LEARNING_TRACK_TODO.md`
 - `docs/DESKTOP.md`
 - `CONTRIBUTING.md`
 - `CODE_OF_CONDUCT.md`

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -16,6 +16,9 @@ mvn spring-boot:run
 - `POST /api/game/start` body: `{ "playerName": "Juan", "bookPath": "C:/.../libro.pdf" }`
 - `GET /api/game/{sessionId}`
 - `POST /api/game/{sessionId}/action` body: `{ "action": "TALK|EXPLORE|CHALLENGE|USE_ITEM", "answerIndex": 1, "itemId": "potion_small" }`
+- `POST /api/game/{sessionId}/autoplay` body: `{ "ageBand": "9-12", "readingLevel": "intermediate", "maxSteps": 3 }`
+- `POST /api/telemetry/events`
+- `GET /api/telemetry/summary`
 
 ## Arquitectura
 - `domain`: entidades de juego.
@@ -24,7 +27,9 @@ mvn spring-boot:run
 - `narrative`: construccion de escenas.
 - `service`: orquestacion de sesiones.
 - `api`: controladores y DTOs.
+- `docs/LEARNING_TRACK_TODO.md`: plan de mejora pedagogica por fases.
 
 ## Notas
 - CORS permitido para `http://localhost:5173`.
 - El frontend empaquetado se copia a `src/main/resources/static` solo durante build desktop.
+- El pipeline narrativo incluye normalizacion de texto, memoria de entidades y nivel cognitivo por escena.

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/GameStateResponse.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/GameStateResponse.java
@@ -16,6 +16,7 @@ public record GameStateResponse(
         int correctAnswers,
         int discoveries,
         Map<String, Integer> inventory,
+        Map<String, Integer> narrativeMemory,
         List<QuestView> quests,
         SceneView currentScene,
         String lastMessage

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/SceneView.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/SceneView.java
@@ -1,5 +1,7 @@
 package com.juegodefinitivo.autobook.api.dto;
 
+import java.util.List;
+
 public record SceneView(
         int index,
         int total,
@@ -7,6 +9,9 @@ public record SceneView(
         String text,
         String eventType,
         String npc,
-        ChallengeView challenge
+        ChallengeView challenge,
+        List<String> entities,
+        String cognitiveLevel,
+        String continuityHint
 ) {
 }

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/AppBeansConfig.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/AppBeansConfig.java
@@ -11,6 +11,7 @@ import com.juegodefinitivo.autobook.ingest.ExtractorResolver;
 import com.juegodefinitivo.autobook.ingest.PdfTextExtractor;
 import com.juegodefinitivo.autobook.ingest.TxtTextExtractor;
 import com.juegodefinitivo.autobook.narrative.DialogueService;
+import com.juegodefinitivo.autobook.narrative.EntityExtractor;
 import com.juegodefinitivo.autobook.narrative.NarrativeBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,8 +42,8 @@ public class AppBeansConfig {
     }
 
     @Bean
-    public NarrativeBuilder narrativeBuilder(AutoQuestionService questionService, Random random) {
-        return new NarrativeBuilder(questionService, random);
+    public NarrativeBuilder narrativeBuilder(AutoQuestionService questionService, EntityExtractor entityExtractor, Random random) {
+        return new NarrativeBuilder(questionService, entityExtractor, random);
     }
 
     @Bean

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/engine/AutoQuestionService.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/engine/AutoQuestionService.java
@@ -27,6 +27,10 @@ public class AutoQuestionService {
     }
 
     public ChallengeQuestion createQuestion(Scene scene) {
+        return createQuestion(scene, "LITERAL");
+    }
+
+    public ChallengeQuestion createQuestion(Scene scene, String cognitiveLevel) {
         List<String> keywords = extractKeywords(scene.text());
         String correct = keywords.isEmpty() ? "historia" : keywords.get(random.nextInt(keywords.size()));
 
@@ -47,11 +51,18 @@ public class AutoQuestionService {
         java.util.Collections.shuffle(optionList, random);
         int correctIndex = optionList.indexOf(correct) + 1;
 
-        return new ChallengeQuestion(
-                "Que palabra aparece en la escena?",
-                optionList,
-                correctIndex
-        );
+        return new ChallengeQuestion(promptFor(cognitiveLevel), optionList, correctIndex);
+    }
+
+    private String promptFor(String cognitiveLevel) {
+        if (cognitiveLevel == null) {
+            return "Que palabra aparece en la escena?";
+        }
+        return switch (cognitiveLevel.toUpperCase(Locale.ROOT)) {
+            case "INFERENCIAL" -> "Que concepto resume mejor lo que ocurre en la escena?";
+            case "CRITICO" -> "Que opcion representa mejor la decision mas sabia en esta escena?";
+            default -> "Que palabra aparece en la escena?";
+        };
     }
 
     private List<String> extractKeywords(String text) {

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/narrative/EntityExtractor.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/narrative/EntityExtractor.java
@@ -1,0 +1,63 @@
+package com.juegodefinitivo.autobook.narrative;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class EntityExtractor {
+
+    private static final Pattern CAPITALIZED_SPAN = Pattern.compile("\\b([A-ZÁÉÍÓÚÑ][\\p{L}]+(?:\\s+[A-ZÁÉÍÓÚÑ][\\p{L}]+){0,2})\\b");
+    private static final List<String> LOCATION_HINTS = List.of(
+            "bosque", "castillo", "puente", "ciudad", "torre", "cueva", "reino", "aldea", "biblioteca"
+    );
+
+    public List<String> extractEntities(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+
+        Set<String> entities = new LinkedHashSet<>();
+        Matcher matcher = CAPITALIZED_SPAN.matcher(text);
+        while (matcher.find()) {
+            String candidate = matcher.group(1).trim();
+            if (candidate.length() >= 3 && !isGeneric(candidate)) {
+                entities.add(candidate);
+            }
+            if (entities.size() >= 8) {
+                break;
+            }
+        }
+
+        String lower = text.toLowerCase(Locale.ROOT);
+        for (String hint : LOCATION_HINTS) {
+            if (lower.contains(hint)) {
+                entities.add("Lugar: " + capitalize(hint));
+            }
+            if (entities.size() >= 10) {
+                break;
+            }
+        }
+
+        return new ArrayList<>(entities);
+    }
+
+    private boolean isGeneric(String value) {
+        String normalized = value.toLowerCase(Locale.ROOT);
+        return normalized.equals("capitulo")
+                || normalized.equals("chapter")
+                || normalized.equals("parte")
+                || normalized.equals("seccion");
+    }
+
+    private String capitalize(String value) {
+        return value.substring(0, 1).toUpperCase(Locale.ROOT) + value.substring(1);
+    }
+}
+

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/narrative/NarrativeBuilder.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/narrative/NarrativeBuilder.java
@@ -19,22 +19,29 @@ public class NarrativeBuilder {
     );
 
     private final AutoQuestionService questionService;
+    private final EntityExtractor entityExtractor;
     private final Random random;
 
-    public NarrativeBuilder(AutoQuestionService questionService, Random random) {
+    public NarrativeBuilder(AutoQuestionService questionService, EntityExtractor entityExtractor, Random random) {
         this.questionService = questionService;
+        this.entityExtractor = entityExtractor;
         this.random = random;
     }
 
     public List<NarrativeScene> build(List<Scene> baseScenes) {
         List<NarrativeScene> output = new ArrayList<>();
+        SceneEventType previousEvent = SceneEventType.DIALOGUE;
+        String previousNpc = NPCS.get(0);
         for (int i = 0; i < baseScenes.size(); i++) {
             Scene scene = baseScenes.get(i);
             String keyword = pickKeyword(scene.text());
-            SceneEventType eventType = chooseEventType(i);
-            String npc = NPCS.get(i % NPCS.size());
-            ChallengeQuestion question = questionService.createQuestion(scene);
+            List<String> entities = entityExtractor.extractEntities(scene.text());
+            String cognitiveLevel = cognitiveLevelFor(i);
+            SceneEventType eventType = chooseEventType(i, previousEvent, scene.text());
+            String npc = chooseNpc(i, entities, previousNpc);
+            ChallengeQuestion question = questionService.createQuestion(scene, cognitiveLevel);
             String discoveryItem = eventType == SceneEventType.DISCOVERY ? "relic_fragment" : "";
+            String continuityHint = continuityHint(previousEvent, eventType, entities);
 
             output.add(new NarrativeScene(
                     i,
@@ -44,21 +51,71 @@ public class NarrativeBuilder {
                     npc,
                     eventType,
                     question,
-                    discoveryItem
+                    discoveryItem,
+                    entities,
+                    cognitiveLevel,
+                    continuityHint
             ));
+            previousEvent = eventType;
+            previousNpc = npc;
         }
         return output;
     }
 
-    private SceneEventType chooseEventType(int index) {
+    private SceneEventType chooseEventType(int index, SceneEventType previous, String text) {
+        String lower = text.toLowerCase(Locale.ROOT);
+        if (lower.contains("pregunta") || lower.contains("reto")) {
+            return SceneEventType.CHALLENGE;
+        }
+        if (lower.contains("descubr") || lower.contains("encuentra")) {
+            return SceneEventType.DISCOVERY;
+        }
+        if (lower.contains("descans") || lower.contains("calma")) {
+            return SceneEventType.REST;
+        }
+
         int pick = index % 5;
-        return switch (pick) {
+        SceneEventType candidate = switch (pick) {
             case 0 -> SceneEventType.DIALOGUE;
             case 1 -> SceneEventType.CHALLENGE;
             case 2 -> SceneEventType.DISCOVERY;
             case 3 -> SceneEventType.BATTLE;
             default -> SceneEventType.REST;
         };
+        if (previous == SceneEventType.BATTLE && candidate == SceneEventType.BATTLE) {
+            return SceneEventType.REST;
+        }
+        return candidate;
+    }
+
+    private String chooseNpc(int index, List<String> entities, String previousNpc) {
+        if (!entities.isEmpty() && entities.get(0).startsWith("Lugar:")) {
+            return "Guia Orion";
+        }
+        if (index > 0 && random.nextInt(100) < 35) {
+            return previousNpc;
+        }
+        return NPCS.get(index % NPCS.size());
+    }
+
+    private String cognitiveLevelFor(int index) {
+        int bucket = index % 3;
+        return switch (bucket) {
+            case 1 -> "INFERENCIAL";
+            case 2 -> "CRITICO";
+            default -> "LITERAL";
+        };
+    }
+
+    private String continuityHint(SceneEventType previous, SceneEventType current, List<String> entities) {
+        String anchor = entities.isEmpty() ? "contexto narrativo" : entities.get(0);
+        if (previous == SceneEventType.BATTLE && current == SceneEventType.REST) {
+            return "Transicion de tension a recuperacion, manteniendo el foco en " + anchor + ".";
+        }
+        if (current == SceneEventType.DISCOVERY) {
+            return "Nueva pista conectada a " + anchor + ".";
+        }
+        return "Mantener continuidad con " + anchor + ".";
     }
 
     private String pickKeyword(String text) {

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/narrative/NarrativeQualityEvaluator.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/narrative/NarrativeQualityEvaluator.java
@@ -1,0 +1,52 @@
+package com.juegodefinitivo.autobook.narrative;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class NarrativeQualityEvaluator {
+
+    public QualityReport evaluate(List<NarrativeScene> scenes) {
+        if (scenes == null || scenes.isEmpty()) {
+            return new QualityReport(0, 0, 0, 0);
+        }
+
+        int avgLength = (int) scenes.stream().mapToInt(scene -> scene.text().length()).average().orElse(0);
+        double continuityCoverage = scenes.stream()
+                .filter(scene -> scene.continuityHint() != null && !scene.continuityHint().isBlank())
+                .count() / (double) scenes.size();
+
+        Set<String> uniqueEntities = scenes.stream()
+                .flatMap(scene -> scene.entities().stream())
+                .collect(Collectors.toSet());
+
+        long cognitiveLevels = scenes.stream()
+                .map(NarrativeScene::cognitiveLevel)
+                .filter(level -> level != null && !level.isBlank())
+                .distinct()
+                .count();
+
+        int score = 0;
+        if (avgLength >= 80 && avgLength <= 520) {
+            score += 35;
+        }
+        if (continuityCoverage >= 0.8) {
+            score += 30;
+        }
+        if (uniqueEntities.size() >= 3) {
+            score += 20;
+        }
+        if (cognitiveLevels >= 2) {
+            score += 15;
+        }
+
+        return new QualityReport(score, avgLength, uniqueEntities.size(), continuityCoverage);
+    }
+
+    public record QualityReport(int score, int averageSceneLength, int uniqueEntities, double continuityCoverage) {
+    }
+}
+

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/narrative/NarrativeScene.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/narrative/NarrativeScene.java
@@ -2,6 +2,8 @@ package com.juegodefinitivo.autobook.narrative;
 
 import com.juegodefinitivo.autobook.domain.ChallengeQuestion;
 
+import java.util.List;
+
 public record NarrativeScene(
         int index,
         String title,
@@ -10,6 +12,9 @@ public record NarrativeScene(
         String npc,
         SceneEventType eventType,
         ChallengeQuestion challengeQuestion,
-        String discoveryItemId
+        String discoveryItemId,
+        List<String> entities,
+        String cognitiveLevel,
+        String continuityHint
 ) {
 }

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/EndToEndFlowTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/EndToEndFlowTest.java
@@ -10,6 +10,7 @@ import com.juegodefinitivo.autobook.ingest.BookTextNormalizer;
 import com.juegodefinitivo.autobook.ingest.ExtractorResolver;
 import com.juegodefinitivo.autobook.ingest.TxtTextExtractor;
 import com.juegodefinitivo.autobook.narrative.DialogueService;
+import com.juegodefinitivo.autobook.narrative.EntityExtractor;
 import com.juegodefinitivo.autobook.narrative.NarrativeBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,7 +33,7 @@ class EndToEndFlowTest {
                 new BookTextNormalizer(),
                 new BookParser()
         );
-        NarrativeBuilder builder = new NarrativeBuilder(new AutoQuestionService(new Random(2)), new Random(2));
+        NarrativeBuilder builder = new NarrativeBuilder(new AutoQuestionService(new Random(2)), new EntityExtractor(), new Random(2));
         GameEngineService engine = new GameEngineService(new DialogueService(), new Random(2));
 
         var scenes = builder.build(loader.loadScenes(book, 320, 4));

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/GameEngineServiceTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/GameEngineServiceTest.java
@@ -32,7 +32,10 @@ class GameEngineServiceTest {
                 "NPC",
                 SceneEventType.DIALOGUE,
                 new ChallengeQuestion("q", List.of("a", "b", "c"), 1),
-                ""
+                "",
+                List.of("NPC"),
+                "LITERAL",
+                "Mantener continuidad con NPC."
         );
 
         var outcome = engine.apply(session, scene, PlayerAction.USE_ITEM, false, "potion_small");

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/ReadingQualityBenchmarkTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/ReadingQualityBenchmarkTest.java
@@ -1,0 +1,35 @@
+package com.juegodefinitivo.autobook;
+
+import com.juegodefinitivo.autobook.domain.Scene;
+import com.juegodefinitivo.autobook.engine.AutoQuestionService;
+import com.juegodefinitivo.autobook.narrative.EntityExtractor;
+import com.juegodefinitivo.autobook.narrative.NarrativeBuilder;
+import com.juegodefinitivo.autobook.narrative.NarrativeQualityEvaluator;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReadingQualityBenchmarkTest {
+
+    @Test
+    void shouldReachMinimumNarrativeQualityThreshold() {
+        List<Scene> baseScenes = List.of(
+                new Scene(0, "Capitulo uno. El Caballero avanza por el bosque con Maia y observa un puente antiguo."),
+                new Scene(1, "Capitulo dos. En el castillo, Maia plantea un reto de lectura sobre la decision correcta."),
+                new Scene(2, "Capitulo tres. Tras la batalla, el grupo descansa en la torre y encuentra una pista."),
+                new Scene(3, "Capitulo cuatro. El equipo vuelve a la biblioteca para conectar la historia completa.")
+        );
+
+        NarrativeBuilder builder = new NarrativeBuilder(new AutoQuestionService(new Random(7)), new EntityExtractor(), new Random(7));
+        NarrativeQualityEvaluator evaluator = new NarrativeQualityEvaluator();
+
+        var narrativeScenes = builder.build(baseScenes);
+        var report = evaluator.evaluate(narrativeScenes);
+
+        assertTrue(report.score() >= 60, "Narrative quality should stay above minimum threshold");
+    }
+}
+

--- a/apps/frontend/e2e/guided-flow.spec.ts
+++ b/apps/frontend/e2e/guided-flow.spec.ts
@@ -81,6 +81,7 @@ function gameState(sessionId: string, score: number, index: number, lastMessage:
     correctAnswers: 1,
     discoveries: 1,
     inventory: { potion_small: 1 },
+    narrativeMemory: { Mentor: 2, "Lugar: Bosque": 1 },
     quests: [
       {
         id: "reader",
@@ -100,6 +101,9 @@ function gameState(sessionId: string, score: number, index: number, lastMessage:
         prompt: "Pregunta?",
         options: ["A", "B", "C", "D"],
       },
+      entities: ["Mentor", "Lugar: Bosque"],
+      cognitiveLevel: "LITERAL",
+      continuityHint: "Mantener continuidad con Mentor.",
     },
     lastMessage,
   };

--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -368,7 +368,7 @@ button:disabled {
 .bottom-grid {
   margin-top: 0.9rem;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.75rem;
 }
 
@@ -440,7 +440,7 @@ button:disabled {
   }
 
   .bottom-grid {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -83,6 +83,13 @@ function App() {
     return Object.entries(state.inventory);
   }, [state]);
 
+  const memoryEntries = useMemo(() => {
+    if (!state) {
+      return [] as Array<[string, number]>;
+    }
+    return Object.entries(state.narrativeMemory).sort((a, b) => b[1] - a[1]).slice(0, 6);
+  }, [state]);
+
   const progress = useMemo(() => {
     if (!state?.currentScene) {
       return 0;
@@ -343,6 +350,15 @@ function App() {
                   <p className="scene-meta">
                     Evento: <strong>{state.currentScene.eventType}</strong> · NPC: <strong>{state.currentScene.npc}</strong>
                   </p>
+                  <p className="scene-meta">
+                    Nivel cognitivo: <strong>{state.currentScene.cognitiveLevel}</strong>
+                  </p>
+                  <p className="scene-meta">{state.currentScene.continuityHint}</p>
+                  {state.currentScene.entities.length > 0 && (
+                    <p className="scene-meta">
+                      Entidades: <strong>{state.currentScene.entities.join(", ")}</strong>
+                    </p>
+                  )}
                   <p className="scene-text">{state.currentScene.text}</p>
                 </article>
               ) : (
@@ -498,6 +514,21 @@ function App() {
                         </li>
                       ))}
                   </ul>
+                </article>
+
+                <article className="mini-panel">
+                  <h4>Memoria narrativa</h4>
+                  {memoryEntries.length === 0 ? (
+                    <p>Sin entidades registradas.</p>
+                  ) : (
+                    <ul>
+                      {memoryEntries.map(([entity, weight]) => (
+                        <li key={entity}>
+                          {entity}: {weight}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </article>
               </section>
             </>

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -17,6 +17,9 @@ export type SceneView = {
   eventType: string;
   npc: string;
   challenge: ChallengeView;
+  entities: string[];
+  cognitiveLevel: string;
+  continuityHint: string;
 };
 
 export type QuestView = {
@@ -39,6 +42,7 @@ export type GameState = {
   correctAnswers: number;
   discoveries: number;
   inventory: Record<string, number>;
+  narrativeMemory: Record<string, number>;
   quests: QuestView[];
   currentScene: SceneView | null;
   lastMessage: string;

--- a/docs/LEARNING_TRACK_TODO.md
+++ b/docs/LEARNING_TRACK_TODO.md
@@ -1,0 +1,36 @@
+# Learning Quality Track TODO
+
+## Objetivo
+Subir la calidad pedagógica y narrativa del producto para que los libros se transformen en experiencias de aprendizaje consistentes y medibles.
+
+## Backlog por fases
+
+### Fase 1 - Ingesta y segmentacion (en progreso)
+- [x] Normalizacion base de texto PDF/TXT.
+- [x] Segmentacion semantica por encabezados de capitulo.
+- [ ] Deteccion de dialogos por hablante.
+- [ ] Segmentacion por unidades de intencion narrativa.
+
+### Fase 2 - Memoria narrativa (en progreso)
+- [x] Extraccion de entidades (personajes/lugares) por escena.
+- [x] Memoria narrativa acumulada por sesion.
+- [ ] Grafo persistente por libro y sesion (nodos + relaciones).
+- [ ] API para consultar historial narrativo completo.
+
+### Fase 3 - Pedagogia adaptativa (en progreso)
+- [x] Niveles cognitivos de pregunta (literal/inferencial/critico).
+- [x] Continuidad narrativa sugerida por escena.
+- [ ] Ajuste dinamico de dificultad segun desempeno historico.
+- [ ] Banco de preguntas por habilidades lectoras.
+
+### Fase 4 - Calidad y benchmark (en progreso)
+- [x] Evaluador de calidad narrativa con score compuesto.
+- [x] Test benchmark minimo en CI.
+- [ ] Dataset de benchmark con 10+ libros reales.
+- [ ] Reporte automatizado por release con score comparativo.
+
+### Fase 5 - Release profesional
+- [ ] Publicar release `v3.3.0` desde `main` con notas pedagogicas.
+- [ ] Incluir KPI de aprendizaje en notas de release.
+- [ ] Definir criterio de aceptacion pedagogica minimo para release.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,7 +7,7 @@
 4. Desktop packaging: `jpackage` con fallback portable.
 
 ## Next Milestones
-1. `v3.2`: persistencia PostgreSQL + migraciones Flyway.
-2. `v3.3`: panel docente y analitica de aprendizaje.
-3. `v3.4`: narracion semantica mejorada y dificultad adaptativa.
-4. `v3.5`: pruebas E2E frontend + pipeline de instalador firmado.
+1. `v3.3`: memoria narrativa, preguntas cognitivas adaptativas y benchmark de calidad.
+2. `v3.4`: persistencia PostgreSQL + migraciones Flyway.
+3. `v3.5`: panel docente y analitica de aprendizaje por estudiante.
+4. `v3.6`: instalador firmado + observabilidad de produccion.


### PR DESCRIPTION
## Summary
- add learning-track TODO document with phased execution plan
- add entity extraction and narrative memory accumulation per session
- expose scene-level entities, cognitive level and continuity hints in API/frontend
- add adaptive cognitive prompts (literal/inferential/critical)
- add narrative quality evaluator and benchmark test in backend
- update roadmap and docs to reflect v3.3 learning-quality focus

## Validation
- apps/backend: mvn test
- apps/frontend: npm run lint
- apps/frontend: npm run build
- apps/frontend: npm run test:e2e