### PR TITLE
feat(learning): persist narrative graph and expose adaptive difficulty

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -17,6 +17,7 @@ mvn spring-boot:run
 - `GET /api/game/{sessionId}`
 - `POST /api/game/{sessionId}/action` body: `{ "action": "TALK|EXPLORE|CHALLENGE|USE_ITEM", "answerIndex": 1, "itemId": "potion_small" }`
 - `POST /api/game/{sessionId}/autoplay` body: `{ "ageBand": "9-12", "readingLevel": "intermediate", "maxSteps": 3 }`
+- `GET /api/game/{sessionId}/graph`
 - `POST /api/telemetry/events`
 - `GET /api/telemetry/summary`
 
@@ -32,4 +33,4 @@ mvn spring-boot:run
 ## Notas
 - CORS permitido para `http://localhost:5173`.
 - El frontend empaquetado se copia a `src/main/resources/static` solo durante build desktop.
-- El pipeline narrativo incluye normalizacion de texto, memoria de entidades y nivel cognitivo por escena.
+- El pipeline narrativo incluye normalizacion de texto, memoria de entidades, grafo de relaciones y nivel cognitivo por escena.

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/GameController.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/GameController.java
@@ -5,6 +5,7 @@ import com.juegodefinitivo.autobook.api.dto.AutoplayRequest;
 import com.juegodefinitivo.autobook.api.dto.BookView;
 import com.juegodefinitivo.autobook.api.dto.GameStateResponse;
 import com.juegodefinitivo.autobook.api.dto.ImportBookRequest;
+import com.juegodefinitivo.autobook.api.dto.NarrativeGraphResponse;
 import com.juegodefinitivo.autobook.api.dto.StartGameRequest;
 import com.juegodefinitivo.autobook.api.dto.TelemetryEventRequest;
 import com.juegodefinitivo.autobook.api.dto.TelemetrySummaryResponse;
@@ -65,6 +66,11 @@ public class GameController {
     @GetMapping("/game/{sessionId}")
     public GameStateResponse getState(@PathVariable String sessionId) {
         return service.getState(sessionId);
+    }
+
+    @GetMapping("/game/{sessionId}/graph")
+    public NarrativeGraphResponse getNarrativeGraph(@PathVariable String sessionId) {
+        return service.getNarrativeGraph(sessionId);
     }
 
     @PostMapping("/game/{sessionId}/action")

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/GameStateResponse.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/GameStateResponse.java
@@ -17,6 +17,7 @@ public record GameStateResponse(
         int discoveries,
         Map<String, Integer> inventory,
         Map<String, Integer> narrativeMemory,
+        String adaptiveDifficulty,
         List<QuestView> quests,
         SceneView currentScene,
         String lastMessage

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/NarrativeGraphResponse.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/NarrativeGraphResponse.java
@@ -1,0 +1,12 @@
+package com.juegodefinitivo.autobook.api.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record NarrativeGraphResponse(
+        String sessionId,
+        Map<String, Integer> nodes,
+        List<NarrativeLinkView> links
+) {
+}
+

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/NarrativeLinkView.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/api/dto/NarrativeLinkView.java
@@ -1,0 +1,5 @@
+package com.juegodefinitivo.autobook.api.dto;
+
+public record NarrativeLinkView(String source, String target, int weight) {
+}
+

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/service/GameFacadeService.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/service/GameFacadeService.java
@@ -3,6 +3,7 @@ package com.juegodefinitivo.autobook.service;
 import com.juegodefinitivo.autobook.api.dto.BookView;
 import com.juegodefinitivo.autobook.api.dto.ChallengeView;
 import com.juegodefinitivo.autobook.api.dto.GameStateResponse;
+import com.juegodefinitivo.autobook.api.dto.NarrativeGraphResponse;
 import com.juegodefinitivo.autobook.api.dto.QuestView;
 import com.juegodefinitivo.autobook.api.dto.SceneView;
 import com.juegodefinitivo.autobook.config.AppConfig;
@@ -39,6 +40,7 @@ public class GameFacadeService {
     private final NarrativeBuilder narrativeBuilder;
     private final GameEngineService engine;
     private final AutoplayService autoplayService;
+    private final NarrativeGraphService narrativeGraphService;
 
     private final Map<String, SessionState> sessions = new ConcurrentHashMap<>();
 
@@ -49,7 +51,8 @@ public class GameFacadeService {
             BookLoaderService loader,
             NarrativeBuilder narrativeBuilder,
             GameEngineService engine,
-            AutoplayService autoplayService
+            AutoplayService autoplayService,
+            NarrativeGraphService narrativeGraphService
     ) {
         this.config = config;
         this.catalog = catalog;
@@ -58,6 +61,7 @@ public class GameFacadeService {
         this.narrativeBuilder = narrativeBuilder;
         this.engine = engine;
         this.autoplayService = autoplayService;
+        this.narrativeGraphService = narrativeGraphService;
     }
 
     public void bootstrapSamples() {
@@ -95,9 +99,9 @@ public class GameFacadeService {
         }
 
         String id = UUID.randomUUID().toString();
-        SessionState boot = new SessionState(session, scenes, "Partida iniciada.", new LinkedHashMap<>());
+        SessionState boot = new SessionState(session, scenes, "Partida iniciada.", new LinkedHashMap<>(), 0, 0);
         if (!scenes.isEmpty()) {
-            boot = absorbEntities(boot, scenes.get(0));
+            boot = absorbEntities(id, boot, scenes.get(0));
         }
         sessions.put(id, boot);
         return toResponse(id, sessions.get(id));
@@ -106,6 +110,11 @@ public class GameFacadeService {
     public GameStateResponse getState(String sessionId) {
         SessionState state = requireSession(sessionId);
         return toResponse(sessionId, state);
+    }
+
+    public NarrativeGraphResponse getNarrativeGraph(String sessionId) {
+        requireSession(sessionId);
+        return narrativeGraphService.snapshot(sessionId);
     }
 
     public GameStateResponse applyAction(String sessionId, String actionValue, Integer answerIndex, String itemId) {
@@ -129,10 +138,11 @@ public class GameFacadeService {
                 throw new IllegalArgumentException("Debes enviar answerIndex para el reto.");
             }
             challengeCorrect = scene.challengeQuestion().isCorrect(answerIndex);
+            state = state.withChallengeAttempt(challengeCorrect);
         }
 
         TurnOutcome outcome = engine.apply(session, scene, action, challengeCorrect, itemId);
-        state = absorbEntities(state, scene);
+        state = absorbEntities(sessionId, state, scene);
         if (outcome.consumedTurn()) {
             engine.moveNextScene(session, state.scenes().size());
         }
@@ -160,9 +170,15 @@ public class GameFacadeService {
             }
 
             NarrativeScene scene = state.scenes().get(session.getCurrentScene());
-            AutoplayService.PlannedTurn planned = autoplayService.planTurn(session, scene, ageBand, readingLevel);
+            String effectiveReadingLevel = (readingLevel == null || readingLevel.isBlank())
+                    ? state.adaptiveDifficulty().toLowerCase()
+                    : readingLevel;
+            AutoplayService.PlannedTurn planned = autoplayService.planTurn(session, scene, ageBand, effectiveReadingLevel);
             TurnOutcome outcome = engine.apply(session, scene, planned.action(), planned.challengeCorrect(), planned.itemId());
-            state = absorbEntities(state, scene);
+            state = absorbEntities(sessionId, state, scene);
+            if (planned.action() == PlayerAction.CHALLENGE) {
+                state = state.withChallengeAttempt(planned.challengeCorrect());
+            }
             if (outcome.consumedTurn()) {
                 engine.moveNextScene(session, state.scenes().size());
             }
@@ -236,13 +252,14 @@ public class GameFacadeService {
                 session.getDiscoveries(),
                 session.getInventory(),
                 state.narrativeMemory(),
+                state.adaptiveDifficulty(),
                 quests,
                 sceneView,
                 state.lastMessage()
         );
     }
 
-    private SessionState absorbEntities(SessionState state, NarrativeScene scene) {
+    private SessionState absorbEntities(String sessionId, SessionState state, NarrativeScene scene) {
         Map<String, Integer> memory = new LinkedHashMap<>(state.narrativeMemory());
         for (String entity : scene.entities()) {
             String key = entity.trim();
@@ -250,6 +267,7 @@ public class GameFacadeService {
                 memory.merge(key, 1, Integer::sum);
             }
         }
+        narrativeGraphService.record(sessionId, scene.entities());
         return state.withMemory(memory);
     }
 
@@ -273,14 +291,36 @@ public class GameFacadeService {
             GameSession session,
             List<NarrativeScene> scenes,
             String lastMessage,
-            Map<String, Integer> narrativeMemory
+            Map<String, Integer> narrativeMemory,
+            int challengeAttempts,
+            int challengeCorrect
     ) {
         private SessionState withMessage(String message) {
-            return new SessionState(session, scenes, message, narrativeMemory);
+            return new SessionState(session, scenes, message, narrativeMemory, challengeAttempts, challengeCorrect);
         }
 
         private SessionState withMemory(Map<String, Integer> memory) {
-            return new SessionState(session, scenes, lastMessage, memory);
+            return new SessionState(session, scenes, lastMessage, memory, challengeAttempts, challengeCorrect);
+        }
+
+        private SessionState withChallengeAttempt(boolean wasCorrect) {
+            int nextAttempts = challengeAttempts + 1;
+            int nextCorrect = challengeCorrect + (wasCorrect ? 1 : 0);
+            return new SessionState(session, scenes, lastMessage, narrativeMemory, nextAttempts, nextCorrect);
+        }
+
+        private String adaptiveDifficulty() {
+            if (challengeAttempts < 2) {
+                return "INTERMEDIATE";
+            }
+            double accuracy = challengeCorrect / (double) challengeAttempts;
+            if (accuracy < 0.45 || session.getLife() < 35) {
+                return "BEGINNER";
+            }
+            if (accuracy > 0.8 && session.getScore() >= 80) {
+                return "ADVANCED";
+            }
+            return "INTERMEDIATE";
         }
     }
 }

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/service/NarrativeGraphService.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/service/NarrativeGraphService.java
@@ -1,0 +1,115 @@
+package com.juegodefinitivo.autobook.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.juegodefinitivo.autobook.api.dto.NarrativeGraphResponse;
+import com.juegodefinitivo.autobook.api.dto.NarrativeLinkView;
+import com.juegodefinitivo.autobook.config.AppConfig;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class NarrativeGraphService {
+
+    private final Path graphDir;
+    private final ObjectMapper objectMapper;
+
+    public NarrativeGraphService(AppConfig config, ObjectMapper objectMapper) {
+        this.graphDir = config.dataDir().resolve("narrative-graphs");
+        this.objectMapper = objectMapper;
+    }
+
+    public NarrativeGraphResponse record(String sessionId, List<String> entities) {
+        if (sessionId == null || sessionId.isBlank()) {
+            throw new IllegalArgumentException("sessionId es requerido.");
+        }
+        GraphData graph = loadGraph(sessionId);
+        List<String> clean = entities == null ? List.of() : entities.stream()
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .distinct()
+                .toList();
+
+        for (String entity : clean) {
+            graph.nodes.merge(entity, 1, Integer::sum);
+        }
+        for (int i = 0; i < clean.size(); i++) {
+            for (int j = i + 1; j < clean.size(); j++) {
+                String a = clean.get(i);
+                String b = clean.get(j);
+                String key = edgeKey(a, b);
+                graph.edges.merge(key, 1, Integer::sum);
+            }
+        }
+        persist(sessionId, graph);
+        return toResponse(sessionId, graph);
+    }
+
+    public NarrativeGraphResponse snapshot(String sessionId) {
+        return toResponse(sessionId, loadGraph(sessionId));
+    }
+
+    private NarrativeGraphResponse toResponse(String sessionId, GraphData graph) {
+        List<NarrativeLinkView> links = new ArrayList<>();
+        graph.edges.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                .limit(20)
+                .forEach(entry -> {
+                    String[] pair = entry.getKey().split("\\|\\|", 2);
+                    String source = pair.length > 0 ? pair[0] : "";
+                    String target = pair.length > 1 ? pair[1] : "";
+                    links.add(new NarrativeLinkView(source, target, entry.getValue()));
+                });
+        return new NarrativeGraphResponse(sessionId, new LinkedHashMap<>(graph.nodes), links);
+    }
+
+    private GraphData loadGraph(String sessionId) {
+        Path file = graphDir.resolve(sessionId + ".json");
+        if (!Files.exists(file)) {
+            return new GraphData(new LinkedHashMap<>(), new LinkedHashMap<>());
+        }
+        try {
+            return objectMapper.readValue(file.toFile(), GraphData.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("No se pudo cargar el grafo narrativo.", e);
+        }
+    }
+
+    private void persist(String sessionId, GraphData graph) {
+        try {
+            Files.createDirectories(graphDir);
+            Path file = graphDir.resolve(sessionId + ".json");
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), graph);
+        } catch (IOException e) {
+            throw new IllegalStateException("No se pudo guardar el grafo narrativo.", e);
+        }
+    }
+
+    private String edgeKey(String a, String b) {
+        if (a.compareToIgnoreCase(b) <= 0) {
+            return a + "||" + b;
+        }
+        return b + "||" + a;
+    }
+
+    public static class GraphData {
+        public Map<String, Integer> nodes = new LinkedHashMap<>();
+        public Map<String, Integer> edges = new LinkedHashMap<>();
+
+        public GraphData() {
+        }
+
+        public GraphData(Map<String, Integer> nodes, Map<String, Integer> edges) {
+            this.nodes = nodes;
+            this.edges = edges;
+        }
+    }
+}
+

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/GameControllerTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/GameControllerTest.java
@@ -45,6 +45,7 @@ class GameControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.sessionId").exists())
                 .andExpect(jsonPath("$.currentScene.title").exists())
+                .andExpect(jsonPath("$.adaptiveDifficulty").exists())
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
@@ -56,7 +57,13 @@ class GameControllerTest {
                         .content(objectMapper.writeValueAsString(new ActionRequest("TALK", null, null))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.lastMessage").exists())
-                .andExpect(jsonPath("$.score").isNumber());
+                .andExpect(jsonPath("$.score").isNumber())
+                .andExpect(jsonPath("$.adaptiveDifficulty").exists());
+
+        mockMvc.perform(get("/api/game/" + sessionId + "/graph"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionId").value(sessionId))
+                .andExpect(jsonPath("$.nodes").exists());
 
         mockMvc.perform(post("/api/game/" + sessionId + "/autoplay")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -36,6 +36,11 @@ npm run build
 - El frontend reporta eventos de setup/juego al backend (`/api/telemetry/events`).
 - Resumen visible en UI (`Telemetria UX`) y disponible por API (`/api/telemetry/summary`).
 
+## Inteligencia narrativa en UI
+- Dificultad adaptativa visible por sesion.
+- Memoria narrativa (entidades mas frecuentes).
+- Relaciones narrativas (grafo top de co-ocurrencias por sesion).
+
 ## E2E
 ```bash
 npm run test:e2e

--- a/apps/frontend/e2e/guided-flow.spec.ts
+++ b/apps/frontend/e2e/guided-flow.spec.ts
@@ -40,6 +40,16 @@ test("guided flow supports start, manual action and autoplay with telemetry", as
     });
   });
 
+  await page.route("**/api/game/**/graph", async (route) => {
+    await route.fulfill({
+      json: {
+        sessionId,
+        nodes: { Mentor: 2, "Lugar: Bosque": 1 },
+        links: [{ source: "Mentor", target: "Lugar: Bosque", weight: 1 }],
+      },
+    });
+  });
+
   await page.route("**/api/telemetry/events", async (route) => {
     totalEvents += 1;
     await route.fulfill({ status: 202 });
@@ -82,6 +92,7 @@ function gameState(sessionId: string, score: number, index: number, lastMessage:
     discoveries: 1,
     inventory: { potion_small: 1 },
     narrativeMemory: { Mentor: 2, "Lugar: Bosque": 1 },
+    adaptiveDifficulty: "INTERMEDIATE",
     quests: [
       {
         id: "reader",

--- a/apps/frontend/src/api.ts
+++ b/apps/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { BookView, GameState, TelemetrySummary } from "./types";
+import type { BookView, GameState, NarrativeGraph, TelemetrySummary } from "./types";
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:8080/api";
 
@@ -60,6 +60,10 @@ export async function sendAction(
 
 export async function loadState(sessionId: string): Promise<GameState> {
   return request<GameState>(`/game/${sessionId}`);
+}
+
+export async function loadNarrativeGraph(sessionId: string): Promise<NarrativeGraph> {
+  return request<NarrativeGraph>(`/game/${sessionId}/graph`);
 }
 
 export async function autoplay(

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -43,6 +43,7 @@ export type GameState = {
   discoveries: number;
   inventory: Record<string, number>;
   narrativeMemory: Record<string, number>;
+  adaptiveDifficulty: string;
   quests: QuestView[];
   currentScene: SceneView | null;
   lastMessage: string;
@@ -52,4 +53,16 @@ export type TelemetrySummary = {
   totalEvents: number;
   byEvent: Record<string, number>;
   byStage: Record<string, number>;
+};
+
+export type NarrativeLink = {
+  source: string;
+  target: string;
+  weight: number;
+};
+
+export type NarrativeGraph = {
+  sessionId: string;
+  nodes: Record<string, number>;
+  links: NarrativeLink[];
 };

--- a/docs/LEARNING_TRACK_TODO.md
+++ b/docs/LEARNING_TRACK_TODO.md
@@ -14,13 +14,13 @@ Subir la calidad pedagógica y narrativa del producto para que los libros se tra
 ### Fase 2 - Memoria narrativa (en progreso)
 - [x] Extraccion de entidades (personajes/lugares) por escena.
 - [x] Memoria narrativa acumulada por sesion.
-- [ ] Grafo persistente por libro y sesion (nodos + relaciones).
+- [x] Grafo persistente por sesion (nodos + relaciones).
 - [ ] API para consultar historial narrativo completo.
 
 ### Fase 3 - Pedagogia adaptativa (en progreso)
 - [x] Niveles cognitivos de pregunta (literal/inferencial/critico).
 - [x] Continuidad narrativa sugerida por escena.
-- [ ] Ajuste dinamico de dificultad segun desempeno historico.
+- [x] Ajuste dinamico base de dificultad segun desempeno historico.
 - [ ] Banco de preguntas por habilidades lectoras.
 
 ### Fase 4 - Calidad y benchmark (en progreso)


### PR DESCRIPTION
## Summary
- add persistent narrative graph service stored under app data directory
- add API endpoint GET /api/game/{sessionId}/graph
- track and expose adaptive difficulty in game state response
- update gameplay flow to persist graph edges while scenes are consumed
- update frontend to display adaptive difficulty and top narrative relations
- update docs for learning track progress and backend/frontend API usage

## Validation
- apps/backend: mvn test
- apps/frontend: npm run lint
- apps/frontend: npm run build
- apps/frontend: npm run test:e2e