### PR TITLE
feat(ingest): improve book reading quality and import hardening

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -45,3 +45,4 @@ mvn spring-boot:run
 - El pipeline narrativo incluye normalizacion de texto, memoria de entidades, grafo de relaciones y nivel cognitivo por escena.
 - Persistencia docente sobre JDBC + Flyway (`classrooms`, `students`, `assignments`, `attempts`).
 - Default local con H2 file DB; PostgreSQL habilitado por variables de entorno Spring datasource.
+- Importacion de libros restringida a `.txt` y `.pdf` con limite configurable (`app.import.max-bytes`, default 25MB).

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/AppBeansConfig.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/AppBeansConfig.java
@@ -68,6 +68,6 @@ public class AppBeansConfig {
 
     @Bean
     public BookImportService bookImportService(AppConfig config) {
-        return new BookImportService(config.booksDir());
+        return new BookImportService(config.booksDir(), config.maxImportBytes());
     }
 }

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/AppConfig.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/AppConfig.java
@@ -7,6 +7,7 @@ public record AppConfig(
         Path dataDir,
         Path saveFile,
         Path booksDir,
+        long maxImportBytes,
         int sceneMaxChars,
         int sceneLinesPerChunk
 ) {

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/ConfigLoader.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/config/ConfigLoader.java
@@ -21,6 +21,7 @@ public class ConfigLoader {
         Path dataDir = Path.of(properties.getProperty("app.data.dir", ".autobook-data")).toAbsolutePath().normalize();
         Path saveFile = dataDir.resolve(properties.getProperty("app.save.file", "savegame.properties"));
         Path booksDir = Path.of(properties.getProperty("app.books.dir", "books")).toAbsolutePath().normalize();
+        long maxImportBytes = Long.parseLong(properties.getProperty("app.import.max-bytes", "26214400"));
 
         int maxChars = Integer.parseInt(properties.getProperty("app.scene.max.chars", "420"));
         int linesPerChunk = Integer.parseInt(properties.getProperty("app.scene.lines-per-chunk", "4"));
@@ -30,6 +31,7 @@ public class ConfigLoader {
                 dataDir,
                 saveFile,
                 booksDir,
+                maxImportBytes,
                 maxChars,
                 linesPerChunk
         );

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/ingest/BookImportService.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/ingest/BookImportService.java
@@ -9,9 +9,15 @@ import java.nio.file.StandardCopyOption;
 public class BookImportService {
 
     private final Path booksDir;
+    private final long maxImportBytes;
 
     public BookImportService(Path booksDir) {
+        this(booksDir, 25L * 1024 * 1024);
+    }
+
+    public BookImportService(Path booksDir, long maxImportBytes) {
         this.booksDir = booksDir;
+        this.maxImportBytes = Math.max(1024, maxImportBytes);
     }
 
     public BookAsset importFromInput(String rawPath) {
@@ -19,13 +25,17 @@ public class BookImportService {
         if (!Files.exists(sourcePath) || !Files.isRegularFile(sourcePath)) {
             throw new IllegalArgumentException("No existe el archivo indicado: " + sourcePath);
         }
+        if (!Files.isReadable(sourcePath)) {
+            throw new IllegalArgumentException("No se puede leer el archivo indicado.");
+        }
+        String format = detectFormat(sourcePath);
+        validateFileSize(sourcePath);
 
         try {
             Files.createDirectories(booksDir);
-            String cleanName = sourcePath.getFileName().toString().replaceAll("\\s+", "-").toLowerCase();
+            String cleanName = sanitizeName(sourcePath.getFileName().toString(), format);
             Path destination = booksDir.resolve(cleanName);
             Files.copy(sourcePath, destination, StandardCopyOption.REPLACE_EXISTING);
-            String format = destination.getFileName().toString().toLowerCase().endsWith(".pdf") ? "pdf" : "txt";
             return new BookAsset(destination.getFileName().toString(), destination.toAbsolutePath().normalize(), format);
         } catch (IOException e) {
             throw new IllegalStateException("No se pudo importar el libro", e);
@@ -41,6 +51,47 @@ public class BookImportService {
         if (input.startsWith("file:///")) {
             return Path.of(URI.create(input)).toAbsolutePath().normalize();
         }
+        if (input.startsWith("file://")) {
+            return Path.of(URI.create(input)).toAbsolutePath().normalize();
+        }
         return Path.of(input).toAbsolutePath().normalize();
+    }
+
+    private String detectFormat(Path sourcePath) {
+        String lower = sourcePath.getFileName().toString().toLowerCase();
+        if (lower.endsWith(".txt")) {
+            return "txt";
+        }
+        if (lower.endsWith(".pdf")) {
+            return "pdf";
+        }
+        throw new IllegalArgumentException("Formato no soportado. Usa .txt o .pdf");
+    }
+
+    private void validateFileSize(Path sourcePath) {
+        try {
+            long size = Files.size(sourcePath);
+            if (size <= 0) {
+                throw new IllegalArgumentException("El archivo esta vacio.");
+            }
+            if (size > maxImportBytes) {
+                throw new IllegalArgumentException("El archivo excede el limite permitido (" + maxImportBytes + " bytes).");
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("No se pudo validar el tamano del archivo.", e);
+        }
+    }
+
+    private String sanitizeName(String originalName, String format) {
+        String baseName = originalName.replaceAll("\\.[^.]+$", "");
+        String safeBase = baseName
+                .toLowerCase()
+                .replaceAll("[^a-z0-9-_]+", "-")
+                .replaceAll("-{2,}", "-")
+                .replaceAll("(^-+|-+$)", "");
+        if (safeBase.isBlank()) {
+            safeBase = "book-import";
+        }
+        return safeBase + "." + format;
     }
 }

--- a/apps/backend/src/main/java/com/juegodefinitivo/autobook/ingest/PdfTextExtractor.java
+++ b/apps/backend/src/main/java/com/juegodefinitivo/autobook/ingest/PdfTextExtractor.java
@@ -12,7 +12,18 @@ public class PdfTextExtractor implements DocumentTextExtractor {
     public String extract(Path path) {
         try (PDDocument document = Loader.loadPDF(path.toFile())) {
             PDFTextStripper stripper = new PDFTextStripper();
-            return stripper.getText(document);
+            stripper.setSortByPosition(true);
+            StringBuilder allText = new StringBuilder();
+            int totalPages = Math.max(1, document.getNumberOfPages());
+            for (int page = 1; page <= totalPages; page++) {
+                stripper.setStartPage(page);
+                stripper.setEndPage(page);
+                allText.append(stripper.getText(document));
+                if (page < totalPages) {
+                    allText.append('\f');
+                }
+            }
+            return allText.toString();
         } catch (IOException e) {
             throw new IllegalArgumentException("No se pudo leer PDF: " + path, e);
         }

--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -2,6 +2,7 @@ app.name=AutoBook Adventure
 app.data.dir=.autobook-data
 app.save.file=savegame.properties
 app.books.dir=books
+app.import.max-bytes=26214400
 app.scene.max.chars=420
 app.scene.lines-per-chunk=4
 

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/BookImportServiceTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/BookImportServiceTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BookImportServiceTest {
@@ -23,5 +25,25 @@ class BookImportServiceTest {
 
         assertTrue(Files.exists(asset.path()));
         assertTrue(asset.title().endsWith(".txt"));
+    }
+
+    @Test
+    void shouldRejectUnsupportedExtension(@TempDir Path tempDir) throws Exception {
+        Path source = tempDir.resolve("sample.docx");
+        Files.writeString(source, "contenido");
+        BookImportService service = new BookImportService(tempDir.resolve("catalog"), 1024 * 1024);
+
+        assertThrows(IllegalArgumentException.class, () -> service.importFromInput(source.toString()));
+    }
+
+    @Test
+    void shouldRejectFilesAboveMaxImportSize(@TempDir Path tempDir) throws Exception {
+        Path source = tempDir.resolve("big-book.txt");
+        byte[] payload = new byte[3000];
+        Arrays.fill(payload, (byte) 'a');
+        Files.write(source, payload);
+        BookImportService service = new BookImportService(tempDir.resolve("catalog"), 1024);
+
+        assertThrows(IllegalArgumentException.class, () -> service.importFromInput(source.toString()));
     }
 }

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/BookTextNormalizerTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/BookTextNormalizerTest.java
@@ -47,5 +47,22 @@ class BookTextNormalizerTest {
 
         assertTrue(clean.contains("historia para ninos."));
     }
+
+    @Test
+    void shouldRemoveIndexLinesAndJoinWrappedParagraphs() {
+        String raw = """
+                Capitulo 1 ............. 9
+                Capitulo 2 ............. 15
+                El caballero miro el castillo
+                y decidio continuar con cautela
+                porque la noche era fria.
+                """;
+
+        String clean = normalizer.normalize(raw);
+
+        assertFalse(clean.contains("Capitulo 1"));
+        assertFalse(clean.contains("Capitulo 2"));
+        assertTrue(clean.contains("El caballero miro el castillo y decidio continuar con cautela porque la noche era fria."));
+    }
 }
 

--- a/apps/backend/src/test/java/com/juegodefinitivo/autobook/PdfTextExtractorTest.java
+++ b/apps/backend/src/test/java/com/juegodefinitivo/autobook/PdfTextExtractorTest.java
@@ -29,13 +29,25 @@ class PdfTextExtractorTest {
                 stream.showText("El caballero aprende a escuchar su corazon.");
                 stream.endText();
             }
+            PDPage page2 = new PDPage(PDRectangle.LETTER);
+            document.addPage(page2);
+            try (PDPageContentStream stream = new PDPageContentStream(document, page2)) {
+                stream.beginText();
+                stream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                stream.newLineAtOffset(100, 700);
+                stream.showText("En la segunda pagina reflexiona y continua.");
+                stream.endText();
+            }
             document.save(pdf.toFile());
         }
 
         PdfTextExtractor extractor = new PdfTextExtractor();
-        String text = extractor.extract(pdf).toLowerCase();
+        String text = extractor.extract(pdf);
+        String normalized = text.toLowerCase();
 
-        assertTrue(text.contains("caballero"));
-        assertTrue(text.contains("corazon"));
+        assertTrue(normalized.contains("caballero"));
+        assertTrue(normalized.contains("corazon"));
+        assertTrue(normalized.contains("segunda pagina"));
+        assertTrue(text.contains("\f"));
     }
 }

--- a/apps/backend/src/test/resources/application.properties
+++ b/apps/backend/src/test/resources/application.properties
@@ -2,6 +2,7 @@ app.name=AutoBook Adventure Test
 app.data.dir=target/test-data
 app.save.file=savegame.properties
 app.books.dir=target/test-books
+app.import.max-bytes=1048576
 app.scene.max.chars=420
 app.scene.lines-per-chunk=4
 

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -12,7 +12,7 @@
 - Agregar estrategia de backup/restore y retencion.
 
 2. Seguridad y robustez
-- Limitar tamano y tipo de archivos importados.
+- Endurecer validaciones de import (MIME real + escaneo anti-archivo malicioso).
 - Validar rutas y endurecer manejo de errores.
 - Agregar rate limiting basico por IP/sesion.
 


### PR DESCRIPTION
## Summary
- harden book import pipeline: extension whitelist (.txt/.pdf), readability checks and max-size validation
- add configurable import size limit (pp.import.max-bytes)
- improve PDF extraction consistency: per-page extraction with page separators and position sorting
- improve normalizer quality: remove TOC/index noise and merge wrapped paragraph lines
- add unit tests covering new import/normalization/extraction behavior

## Validation
- mvn test
